### PR TITLE
fix(template): align release automation and CI baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+# Backend-first default CI only. Desktop/Tauri validation stays opt-in and local.
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,5 +1,7 @@
 name: Quality Gate (Secondary/Governance)
 
+# Backend/platform governance only. Desktop/Tauri checks are intentionally excluded from default CI.
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,11 +15,11 @@ concurrency:
 
 jobs:
   release-line:
-    name: Detect Active Release Line
+    name: Detect Repository Release Bootstrap
     runs-on: ubuntu-latest
 
     outputs:
-      has_v0_1_tag: ${{ steps.detect.outputs.has_v0_1_tag }}
+      has_repo_tag: ${{ steps.detect.outputs.has_repo_tag }}
 
     steps:
       - name: Checkout
@@ -27,14 +27,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect official 0.1.x tags
+      - name: Detect official repository semver tags
         id: detect
         run: |
-          if git tag -l 'v0.1.*' | grep -q .; then
-            echo "has_v0_1_tag=true" >> "$GITHUB_OUTPUT"
+          if git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -q .; then
+            echo "has_repo_tag=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_v0_1_tag=false" >> "$GITHUB_OUTPUT"
-            echo "No official v0.1.x tag found yet. Bootstrap the first repository release manually as v0.1.0, then let release-plz continue the 0.1.x line." >> "$GITHUB_STEP_SUMMARY"
+            echo "has_repo_tag=false" >> "$GITHUB_OUTPUT"
+            echo "No official repository semver tag found yet. Bootstrap the first repository release manually with your chosen starting tag, then let release-plz continue from there." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   semver:
@@ -64,7 +64,7 @@ jobs:
     name: Release PR
     runs-on: ubuntu-latest
     needs: [release-line, semver]
-    if: needs.release-line.outputs.has_v0_1_tag == 'true'
+    if: needs.release-line.outputs.has_repo_tag == 'true'
 
     steps:
       - name: Checkout
@@ -85,7 +85,7 @@ jobs:
 
   release:
     name: GitHub Release
-    if: github.event_name == 'workflow_dispatch' && needs.release-line.outputs.has_v0_1_tag == 'true'
+    if: github.event_name == 'workflow_dispatch' && needs.release-line.outputs.has_repo_tag == 'true'
     runs-on: ubuntu-latest
     needs: [release-line, semver]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this repository-level template are documented here.
+
+This project ships as one template product:
+
+- Repository tags and GitHub Releases are the public version contract.
+- Internal Cargo crate versions remain workspace metadata for tooling.
+- `release-plz` prepares release updates from merged conventional commits.
+
+Preferred release views:
+
+- Releases: <https://github.com/openclosed-org/axum-harness/releases>
+- Tags: <https://github.com/openclosed-org/axum-harness/tags>
+
+## Unreleased
+
+### Changed
+
+- Aligned repository release automation and SemVer checks with the latest real template baseline instead of the old hard-coded `v0.1.x` line.
+- Clarified in README and maintainer docs that repository tags are the template version contract and that desktop/Tauri validation is local-only, not part of the default backend CI admission flow.
+- Reworked Quick Start and local development guidance to emphasize the backend-first path and remove stale or misleading command examples.
+- Fixed multiple broken or outdated `just` recipes in backend/platform workflows, including SemVer baseline detection, platform inventory commands, migration helpers, process utilities, and stale package/path references.
+- Added a repository-level changelog entry point so release notes have an explicit home in the template itself.
+
+### Notes
+
+- The active baseline tag in this repository remains `v0.2.0`.
+- GitHub Releases remains the best public view for generated release notes once release automation runs.
+
+## v0.2.0 - 2026-04-04
+
+### Notes
+
+- Current repository baseline tag for the template line.
+- Tagged from commit `95ae1c9` (`chore: archive v0.2.0 milestone`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ If a change crosses multiple domains, preserve the existing boundaries rather th
 
 Run the smallest relevant validation set for your change, then run the global gate before merging.
 
+Desktop/Tauri is not part of the default CI contract for this repository. If your change touches `apps/desktop/**` or desktop-specific runtime behavior, run the desktop commands explicitly on the target OS instead of assuming the backend CI lanes cover it.
+
 Common commands:
 
 ```bash
@@ -103,7 +105,7 @@ Only claim checks passed if you actually ran them.
 ## Commit and release semantics
 
 - This repository is versioned as one template product using repository-level SemVer.
-- The active repository release line is `0.1.x`; keep iterating there until there is a deliberate reason to open a new pre-1.0 line or to declare `1.0.0` stability.
+- Follow the latest repository tag/release as the active template line until there is a deliberate reason to open a new pre-1.0 line or to declare `1.0.0` stability.
 - Prefer conventional commits such as `feat:`, `fix:`, `docs:`, `refactor:`, `ci:`, and `chore:`.
 - Use scopes when they add signal, for example `feat(template):`, `fix(bff):`, `docs(readme):`, `refactor(worker-runtime):`.
 - If a change alters template defaults, project layout, setup flow, or migration expectations for template users, call that out explicitly in the PR description and release notes.
@@ -113,12 +115,12 @@ Only claim checks passed if you actually ran them.
 
 - This repository uses `release-plz` for repository release preparation.
 - Maintainers should prefer conventional commits such as `feat:`, `fix:`, and `docs:` so generated changelogs stay readable.
-- Bootstrap the first official repository release manually as `v0.1.0`; after that, let release automation continue the `0.1.x` line.
+- If you derive a new repository from this template, bootstrap the first official repository release manually with your chosen starting tag; after that, let release automation continue from that baseline.
 - `release-plz` opens a release PR on `main` and prepares version/changelog updates from merged commits.
 - Most binaries/internal crates are configured with `publish = false`, so release automation can still generate changelogs and GitHub releases without requiring every crate to publish to crates.io.
 - The SemVer contract users should rely on first is the repository tag/release, because this repo is primarily shipped as a template rather than as a set of independently consumed crates.
 - Cargo crate versions are still required for workspace tooling, but they are not independent product version promises.
-- Use `just semver-check` locally when validating repository-level compatibility assumptions for the current `0.1.x` line.
+- Use `just semver-check` locally when validating repository-level compatibility assumptions for the current template line.
 
 ## Reporting bugs and features
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Backend-in-Rust Template and Reference Architecture
 
+[![Template version](https://img.shields.io/github/v/tag/openclosed-org/axum-harness?sort=semver&label=template%20version)](https://github.com/openclosed-org/axum-harness/tags)
+[![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-blue)](./CHANGELOG.md)
+[![Release notes](https://img.shields.io/badge/release%20notes-GitHub-blueviolet)](https://github.com/openclosed-org/axum-harness/releases)
+
 > Backend-first, semantic-first, topology-late, agent-native template architecture — with DDD, CAS, unified outbox, projection, workflow, and a multi-agent AI harness. Built entirely in Rust.
 >
 > Single VPS → K3s cluster → multi-service topology. Same code, different platform model.
@@ -7,6 +11,8 @@
 **What this is:** A backend-first template and living reference architecture for building resilient Rust backends. Every service owns its state, every mutation uses CAS + idempotency, every event flows through a unified outbox, and every projection is rebuildable from source.
 
 **What makes it different:** A [multi-agent AI harness](#-for-ai-agents) that routes tasks to domain-specialized subagents, enforces architectural boundaries, and gates every change — humans and AI co-develop under the same protocol.
+
+> **Template version contract:** Track the repository tag/release as the template version. Individual Cargo crate versions are internal workspace metadata for tooling and do not represent separate product release channels.
 
 ## Reality Check
 
@@ -28,6 +34,12 @@ Use it as a strong starting point, not as proof that every pattern here is alrea
 - **Single VPS to K3s** — `platform/model/topologies/*.yaml` defines the deployment shape. Same binary, different topology.
 - **SOPS + Flux GitOps** — Backend secrets flow through SOPS/Kustomize/Flux, not `.env` files. `just sops-run <deployable>` injects env vars locally; Flux reconciles in-cluster.
 - **Multi-agent AI harness** — 8 specialized agents (planner, platform-ops, contract, service, server, worker, app-shell) with routing rules, scoped gates, and boundary checks.
+
+## Versioning and Changelog
+
+- **Template version source of truth** — the latest repository tag under GitHub [Tags](https://github.com/openclosed-org/axum-harness/tags) or [Releases](https://github.com/openclosed-org/axum-harness/releases).
+- **Change history** — the root [`CHANGELOG.md`](./CHANGELOG.md) is the repository-level entry point; GitHub Releases is the best public view for release notes.
+- **Derived projects** — if you use this repo as a template, you can keep repository-level tags if you want to preserve upstream upgrade visibility; if not, you can replace the release flow with your own product versioning.
 
 ## Architecture at a Glance
 
@@ -115,7 +127,7 @@ There are two primary user modes for this repository:
 
 Template users should treat the repository release as the main contract and keep only the parts relevant to their project.
 
-The current release strategy is one repository-level `0.1.x` line for the template as a whole. Cargo crate versions remain internal workspace metadata, not separate product release channels.
+The release strategy is repository-level SemVer for the template as a whole. Cargo crate versions remain internal workspace metadata, not separate product release channels.
 
 Contributors should treat the repository structure, gates, agent protocol, and documentation conventions as part of the design, not as optional extras.
 
@@ -124,24 +136,37 @@ A dedicated `just template-init` cleanup flow now exists as a conservative plann
 ## Quick Start
 
 ```bash
-# 1. Install toolchain
+# 1. Install and verify the toolchain
 just setup
 just setup-deps
 just doctor
 
-# 2. Start local infra (NATS, Valkey, MinIO)
+# 2. Optional: preview template cleanup scope
+just template-init backend-core dry-run
+
+# 3. Start local infra (NATS, Valkey, MinIO)
 bash infra/local/scripts/bootstrap.sh up
 
-# 3. Run the backend
-just dev-api          # web-bff
-just sops-run web-bff # with SOPS-decrypted secrets
+# 4. Run the backend
+just dev-api
 
-# 4. Run all quality checks
+# 5. Run stricter checks when you are ready
+just validate-platform
+just semver-check
 just verify
 
-# 5. Platform health
-just validate-platform
-just platform-doctor
+# Optional: run with SOPS-managed secrets after local SOPS setup
+just sops-run web-bff dev
+```
+
+Desktop/Tauri is intentionally kept out of the default CI and backend verification flow.
+Use it as a local-only shell when you specifically need desktop validation on your own machine.
+
+```bash
+# Optional: local desktop shell only
+just dev-desktop
+just dev-tauri
+just test-desktop
 ```
 
 ```bash
@@ -156,7 +181,7 @@ If you adopt this repository via GitHub "Use this template", the shortest useful
 2. `docs/operations/local-dev.md`
 3. `docs/operations/secret-management.md`
 4. `docs/operations/counter-service-reference-chain.md`
-5. `just template-init PROFILE=backend-core MODE=dry-run`
+5. `just template-init backend-core dry-run`
 
 The current `template-init` flow is intentionally conservative. It is meant to help derived projects identify upstream-maintainer artifacts to review or remove; it is not a code-pruning tool.
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,15 +6,15 @@
   "build": {
     "beforeDevCommand": {
       "script": "bun run dev",
-      "cwd": "../../web/app",
+      "cwd": "../../web",
       "wait": false
     },
     "devUrl": "http://localhost:5173",
     "beforeBuildCommand": {
       "script": "bun run build",
-      "cwd": "../../web/app"
+      "cwd": "../../web"
     },
-    "frontendDist": "../../web/app/build"
+    "frontendDist": "../../web/build"
   },
   "app": {
     "windows": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,16 +60,16 @@ Repository-level policy and project-level caveats live here instead of expanding
 
 This repository is versioned as a single template product.
 
-1. the current release line is `0.1.x` while the template contract is still converging
-2. `0.1.x` releases cover iterative template improvements, docs fixes, tooling updates, and internal refactors within the current pre-1.0 line
-3. `0.2.0` should only start a new pre-1.0 line when template structure, migration expectations, or public usage patterns change materially
-4. `1.0.0` should start only when the template is ready to make a stronger stability promise to adopters
+1. the repository tag/release is the version contract template users should follow
+2. pre-`1.0.0` releases cover iterative template improvements, docs fixes, tooling updates, and internal refactors within the active pre-1.0 line
+3. bump the minor version when template structure, migration expectations, or public usage patterns change materially
+4. start `1.0.0` only when the template is ready to make a stronger stability promise to adopters
 
 Cargo crate versions still exist as workspace metadata, but they do not represent independent product release channels.
 
-Bootstrap the first official repository release manually as `v0.1.0`. After that, automation can continue the `0.1.x` line.
+If you derive a new repository from this template, bootstrap the first official repository release manually with your chosen starting tag, then let automation continue from there.
 
-`release-plz` prepares repository releases, and `just semver-check` is the local visibility check for repository-level compatibility assumptions within the active `0.1.x` line.
+`release-plz` prepares repository releases, and `just semver-check` is the local visibility check for repository-level compatibility assumptions within the active pre-1.0 line.
 
 ### Configuration
 
@@ -80,6 +80,14 @@ There are three different configuration paths and they should not be confused:
 3. local tooling or desktop convenience path: `.env`, which is not the canonical backend secrets path
 
 If you are working on backend deployables, prefer the first path by default.
+
+### Desktop Scope
+
+Desktop/Tauri is a local convenience shell in this repository, not part of the default backend CI contract.
+
+1. default GitHub CI covers backend, platform, contracts, and web-facing verification lanes
+2. desktop and Tauri validation stay opt-in and local because cross-platform packaging and debugging requirements are materially different across macOS, Linux, and Windows
+3. if you change `apps/desktop/**`, run the desktop checks explicitly instead of assuming the default CI lanes cover them
 
 ### Architecture Rules
 

--- a/docs/operations/local-dev.md
+++ b/docs/operations/local-dev.md
@@ -88,7 +88,7 @@ source infra/local/generated/auth.env
 just dev
 just dev-web
 just dev-api
-just dev-admin-bff
+just dev-desktop
 just auth-bootstrap
 just auth-up
 just auth-down
@@ -99,9 +99,16 @@ just auth-down
 1. `just dev-web` 对应 web 开发主路径。
 2. `just dev-api` 是更贴近后端默认视角的入口之一。
 3. 是否需要同时启动前端壳层，取决于当前任务，不应作为所有后端任务的默认要求。
-4. `just auth-bootstrap` 会把本地 `Zitadel/OpenFGA` 起起来，并生成 `infra/local/generated/auth.env` 供 `web-bff` 直接读取。
-5. `just verify-backend-primary` / `just test-backend-primary` 对应默认后端 admission lane。
-6. `just verify-auth-optional` / `just test-auth-optional` 仅在 auth lane 变更时需要额外运行。
+4. `just dev-desktop` 是桌面壳层开发入口，仅在需要 Tauri 验证时使用。
+5. `just auth-bootstrap` 会把本地 `Zitadel/OpenFGA` 起起来，并生成 `infra/local/generated/auth.env` 供 `web-bff` 直接读取。
+6. `just verify-backend-primary` / `just test-backend-primary` 对应默认后端 admission lane。
+7. `just verify-auth-optional` / `just test-auth-optional` 仅在 auth lane 变更时需要额外运行。
+
+补充约束：
+
+1. `just dev-desktop` / `just dev-tauri` / `just test-desktop` 是本地可选入口，不属于默认 CI。
+2. 如果你的任务不涉及 `apps/desktop/**`，不要把 Tauri 当成必须前置条件。
+3. 如果你的任务涉及桌面壳层，请在本机对应操作系统上显式验证，不要假设 Ubuntu CI 能替代 macOS / Windows 行为。
 
 ### 3.3.1 后端优先的最小调试模式
 

--- a/justfiles/build.just
+++ b/justfiles/build.just
@@ -26,11 +26,11 @@ build-macos-aarch64:
 
 # Build API server only
 build-api:
-    cargo build -p api-server --release
+    cargo build -p web-bff --release
 
 # Build Tauri desktop app
 build-tauri:
-    cd apps/client/native/src-tauri && cargo tauri build
+    cargo tauri build --manifest-path apps/desktop/src-tauri/Cargo.toml
 
 # Analyze binary size
 bloat:

--- a/justfiles/clean.just
+++ b/justfiles/clean.just
@@ -29,8 +29,8 @@ clean-tmp:
 clean-tmp-truncate:
     @echo "截断大日志文件（>10MB，保留最后 5 万行）..."
     @find .tmp -name "*.log" -size +10M 2>/dev/null | while read f; do \
-        echo "  截断 $$f"; \
-        tail -n 50000 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; \
+        echo "  截断 $f"; \
+        tail -n 50000 "$f" > "$f.tmp" && mv "$f.tmp" "$f"; \
     done
     @echo "✓ 大日志文件已截断"
 

--- a/justfiles/deploy.just
+++ b/justfiles/deploy.just
@@ -92,7 +92,7 @@ logs-api:
 
 # 检查 storage-turso 编译
 check-storage-turso:
-    cargo check -p web-bff -p admin-bff
+    cargo check -p web-bff
 
 # 构建桌面 E2E 二进制
 build-desktop-bin:

--- a/justfiles/dev.just
+++ b/justfiles/dev.just
@@ -1,6 +1,6 @@
 # Development — all dev server commands
 
-# 启动全栈开发（web-bff + admin-bff + web）
+# 启动全栈开发（web-bff + web）
 dev:
     moon run repo:dev-fullstack
 
@@ -12,14 +12,10 @@ dev-web:
 dev-api:
     moon run repo:dev-api
 
-# 启动 Admin BFF 开发
-dev-admin-bff:
-    moon run repo:dev-admin-bff
-
 # 启动桌面应用开发
 dev-desktop:
     moon run repo:dev-desktop
 
 # 启动 Tauri 桌面应用（手动调试用）
 dev-tauri:
-    cd apps/client/native/src-tauri && cargo tauri dev
+    cargo tauri dev --manifest-path apps/desktop/src-tauri/Cargo.toml

--- a/justfiles/migrate.just
+++ b/justfiles/migrate.just
@@ -25,23 +25,24 @@ migrate-status:
     @echo "  - storage_surrealdb: Programmatic table creation"
     @echo ""
     @echo "Tables in embedded Turso:"
-    @if command -v sqlite3 &>/dev/null; then \
+    @if command -v sqlite3 >/dev/null 2>&1; then \
         sqlite3 servers/bff/web-bff/.data/web-bff.db ".tables" 2>/dev/null || echo "  (database not yet created)"; \
     else \
         echo "  sqlite3 not installed. Run: brew install sqlite"; \
     fi
 
 # Create a new migration file
+# Usage: just migrate-create add_counter_index
 migrate-create NAME='':
     @if [ -z "{{NAME}}" ]; then \
-        echo "Usage: just migrate-create <migration_name>"; \
+        echo "Usage: just migrate-create add_counter_index"; \
         exit 1; \
     fi
-    @TIMESTAMP=$$(date +%Y%m%d%H%M%S); \
-    MIGRATION_FILE="ops/migrations/api/$${TIMESTAMP}_{{NAME}}.sql"; \
+    @TIMESTAMP=$(date +%Y%m%d%H%M%S); \
+    MIGRATION_FILE="ops/migrations/api/${TIMESTAMP}_{{NAME}}.sql"; \
     mkdir -p ops/migrations/api; \
-    touch "$$MIGRATION_FILE"; \
-    echo "Created migration: $$MIGRATION_FILE"
+    touch "$MIGRATION_FILE"; \
+    echo "Created migration: $MIGRATION_FILE"
 
 # Reset database (dev only — DESTRUCTIVE)
 migrate-reset:

--- a/justfiles/platform.just
+++ b/justfiles/platform.just
@@ -92,7 +92,8 @@ gen-sdk:
 # Clean generated SDKs
 clean-sdk:
     @echo "Cleaning generated SDKs..."
-    rm -rf packages/sdk/typescript/!(.gitkeep) packages/sdk/rust/!(.gitkeep) 2>/dev/null || true
+    @find packages/sdk/typescript -mindepth 1 -depth ! -name '.gitkeep' -exec rm -rf {} + 2>/dev/null || true
+    @echo "Skipping packages/sdk/rust cleanup because those files are tracked in-repo today"
     @echo "SDKs cleaned"
 
 # ── Golden Baseline Verification ──────────────────────────────
@@ -153,24 +154,24 @@ platform-doctor:
 
 # List all services defined in platform model
 platform-services:
-	@echo "Services defined in platform model:"
-	@for f in platform/model/services/*.yaml; do \
-		name=$$(basename "$$f" .yaml); \
-		echo "  - $$name"; \
-	done
+    @echo "Services defined in platform model:"
+    @for f in platform/model/services/*.yaml; do \
+        name=$(basename "$f" .yaml); \
+        echo "  - $name"; \
+    done
 
 # List all deployables defined in platform model
 platform-deployables:
-	@echo "Deployables defined in platform model:"
-	@for f in platform/model/deployables/*.yaml; do \
-		name=$$(basename "$$f" .yaml); \
-		echo "  - $$name"; \
-	done
+    @echo "Deployables defined in platform model:"
+    @for f in platform/model/deployables/*.yaml; do \
+        name=$(basename "$f" .yaml); \
+        echo "  - $name"; \
+    done
 
 # List all resources defined in platform model
 platform-resources:
-	@echo "Resources defined in platform model:"
-	@for f in platform/model/resources/*.yaml; do \
-		name=$$(basename "$$f" .yaml); \
-		echo "  - $$name"; \
-	done
+    @echo "Resources defined in platform model:"
+    @for f in platform/model/resources/*.yaml; do \
+        name=$(basename "$f" .yaml); \
+        echo "  - $name"; \
+    done

--- a/justfiles/processes.just
+++ b/justfiles/processes.just
@@ -12,13 +12,6 @@ ps:
         lsof -i :3010 2>/dev/null | grep LISTEN || echo "  [STOPPED]"; \
     fi
     @echo ""
-    @echo "--- Admin BFF Server (port 3020) ---"
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort 3020 -ErrorAction SilentlyContinue | Select-Object OwningProcess | Where-Object OwningProcess -gt 0 | ForEach-Object { Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue | Select-Object Id,ProcessName,StartTime }" 2>/dev/null || echo "  [STOPPED]"; \
-    else \
-        lsof -i :3020 2>/dev/null | grep LISTEN || echo "  [STOPPED]"; \
-    fi
-    @echo ""
     @echo "--- Vite Dev Server (port 5173) ---"
     @if [ "{{os_family()}}" = "windows" ]; then \
         powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort 5173 -ErrorAction SilentlyContinue | Select-Object OwningProcess | Where-Object OwningProcess -gt 0 | ForEach-Object { Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue | Select-Object Id,ProcessName,StartTime }" 2>/dev/null || echo "  [STOPPED]"; \
@@ -37,23 +30,21 @@ ps:
     @if [ "{{os_family()}}" = "windows" ]; then \
         powershell -NoProfile -Command "Get-Process | Where-Object { $_.Responding -eq $false } | Select-Object Id,ProcessName,Responding" 2>/dev/null || echo "  [NONE]"; \
     else \
-        ps aux | grep -E "Z|defunct" | grep -v grep || echo "  [NONE]"; \
+        ps -axo user=,pid=,stat=,start=,time=,command= | awk '$3 ~ /^Z/ { print }' || echo "  [NONE]"; \
     fi
 
 # 停止所有本项目启动的开发进程
 stop:
     @echo "正在停止所有开发进程..."
     @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'cargo run' -or $_.ProcessName -match 'web-bff' -or $_.ProcessName -match 'admin-bff' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [BFF servers stopped]"; \
+        powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'cargo run' -or $_.ProcessName -match 'web-bff' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [BFF servers stopped]"; \
         powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'cargo tauri dev' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [Tauri dev stopped]"; \
         powershell -NoProfile -Command "Get-Process -Name 'native-tauri' -ErrorAction SilentlyContinue | Stop-Process -Force" 2>/dev/null; echo "  [native-tauri stopped]"; \
         powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'vite dev' -or $_.CommandLine -match 'bun run dev' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [Vite dev stopped]"; \
         powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'moon run repo:dev' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [moon tasks stopped]"; \
     else \
         pkill -f "cargo run -p web-bff" 2>/dev/null && echo "  ✓ Web BFF stopped" || echo "  - Web BFF not running"; \
-        pkill -f "cargo run -p admin-bff" 2>/dev/null && echo "  ✓ Admin BFF stopped" || echo "  - Admin BFF not running"; \
         pkill -f "web-bff" 2>/dev/null && echo "  ✓ web-bff stopped" || true; \
-        pkill -f "admin-bff" 2>/dev/null && echo "  ✓ admin-bff stopped" || true; \
         pkill -f "cargo tauri dev" 2>/dev/null && echo "  ✓ Tauri dev stopped" || echo "  - Tauri dev not running"; \
         pkill -f "native-tauri" 2>/dev/null && echo "  ✓ native-tauri stopped" || echo "  - native-tauri not running"; \
         pkill -f "cd ../web/app && bun run dev" 2>/dev/null && echo "  ✓ Vite (Tauri child) stopped" || true; \
@@ -65,11 +56,16 @@ stop:
 
 # 停止指定端口的进程
 stop-port PORT='':
-    @test -n "{{PORT}}" || (echo "Usage: just stop-port PORT=3010" && exit 1)
+    @test -n "{{PORT}}" || (echo "Usage: just stop-port 3010" && exit 1)
     @if [ "{{os_family()}}" = "windows" ]; then \
         powershell -NoProfile -Command "$conn = Get-NetTCPConnection -LocalPort {{PORT}} -ErrorAction SilentlyContinue; if ($conn) { Stop-Process -Id $conn.OwningProcess -Force; echo '  ✓ Port {{PORT}} freed' } else { echo '  - Nothing on port {{PORT}}' }"; \
     else \
-        lsof -ti :{{PORT}} 2>/dev/null | xargs kill -9 2>/dev/null && echo "  ✓ Port {{PORT}} freed" || echo "  - Nothing on port {{PORT}}"; \
+        PIDS=$(lsof -ti :{{PORT}} 2>/dev/null || true); \
+        if [ -n "$PIDS" ]; then \
+            kill -9 $PIDS 2>/dev/null && echo "  ✓ Port {{PORT}} freed" || echo "  - Failed to free port {{PORT}}"; \
+        else \
+            echo "  - Nothing on port {{PORT}}"; \
+        fi; \
     fi
 
 # 清理所有孤儿/无响应进程（当前用户的）
@@ -78,7 +74,12 @@ clean-orphans:
     @if [ "{{os_family()}}" = "windows" ]; then \
         powershell -NoProfile -Command "Get-Process | Where-Object { $_.Responding -eq $false -and $_.SessionId -eq (Get-Process -Id $PID).SessionId } | Stop-Process -Force -ErrorAction SilentlyContinue; echo '  ✓ Non-responding processes cleaned'"; \
     else \
-        ps aux | awk '$8 ~ /Z/ {print $2}' | xargs -r kill -9 2>/dev/null && echo "  ✓ Zombie processes cleaned" || echo "  - No zombie processes found"; \
+        PIDS=$(ps -axo pid=,stat= | awk '$2 ~ /^Z/ {print $1}'); \
+        if [ -n "$PIDS" ]; then \
+            kill -9 $PIDS 2>/dev/null && echo "  ✓ Zombie processes cleaned" || echo "  - Failed to clean zombie processes"; \
+        else \
+            echo "  - No zombie processes found"; \
+        fi; \
     fi
     @echo "完成"
 
@@ -91,13 +92,6 @@ ports:
         powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort 3010 -ErrorAction SilentlyContinue | ForEach-Object { Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue | Select-Object Id,ProcessName }" 2>/dev/null || echo "  [FREE]"; \
     else \
         lsof -i :3010 2>/dev/null | grep -v COMMAND || echo "  [FREE]"; \
-    fi
-    @echo ""
-    @echo "Port 3020 (Admin BFF):"
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort 3020 -ErrorAction SilentlyContinue | ForEach-Object { Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue | Select-Object Id,ProcessName }" 2>/dev/null || echo "  [FREE]"; \
-    else \
-        lsof -i :3020 2>/dev/null | grep -v COMMAND || echo "  [FREE]"; \
     fi
     @echo ""
     @echo "Port 5173 (Vite):"

--- a/justfiles/template.just
+++ b/justfiles/template.just
@@ -4,7 +4,7 @@
 template-init PROFILE='backend-core' MODE='dry-run':
     bun run scripts/template-init.ts --profile "{{PROFILE}}" --mode "{{MODE}}"
 
-# Repository-level SemVer check for the current 0.1.x template line.
+# Repository-level SemVer check for the current template release line.
 semver-check BASELINE='' RELEASE_TYPE='minor':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -12,19 +12,23 @@ semver-check BASELINE='' RELEASE_TYPE='minor':
     release_type="{{RELEASE_TYPE}}"
 
     if [ -z "$baseline" ]; then
-      baseline="$(git tag -l 'v0.1.*' | sort -V | tail -n 1)"
+      baseline="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
     fi
 
     if [ -z "$baseline" ]; then
-      echo "No v0.1.x repository tag found; skipping SemVer baseline check until the first official 0.1.x release exists."
+      echo "No repository semver tag found; skipping SemVer baseline check until the first official template release exists."
       exit 0
     fi
 
     echo "Using SemVer baseline: $baseline"
     echo "Using release type: $release_type"
 
-    cargo semver-checks --baseline-rev "$baseline" --release-type "$release_type" --package contracts_api
-    cargo semver-checks --baseline-rev "$baseline" --release-type "$release_type" --package contracts_events
-    cargo semver-checks --baseline-rev "$baseline" --release-type "$release_type" --package contracts_errors
-    cargo semver-checks --baseline-rev "$baseline" --release-type "$release_type" --package contracts_auth
-    cargo semver-checks --baseline-rev "$baseline" --release-type "$release_type" --package sdk-counter
+    packages="contracts_api contracts_events contracts_errors contracts_auth sdk-counter"
+
+    for pkg in $packages; do
+      if git cat-file -e "$baseline:$(cargo metadata --no-deps --format-version 1 | jq -r --arg pkg "$pkg" '.packages[] | select(.name == $pkg) | .manifest_path' | sed 's#^.*/tauri-sveltekit-axum-moon-template/##')" 2>/dev/null; then
+        cargo semver-checks --baseline-rev "$baseline" --release-type "$release_type" --package "$pkg"
+      else
+        echo "Skipping $pkg: package did not exist at baseline $baseline"
+      fi
+    done

--- a/justfiles/test.just
+++ b/justfiles/test.just
@@ -59,8 +59,8 @@ test-desktop:
 
 # 快速运行 E2E（使用 e2e profile,跳过优化编译）
 test-desktop-fast:
-    cd {{justfile_directory()}} && cargo build -p native-tauri --profile e2e --features e2e-testing
-    cd {{justfile_directory()}}/e2e-desktop-playwright && bun run test:desktop:core
+    cargo build -p native-tauri --profile e2e --features e2e-testing
+    bun --cwd {{justfile_directory()}}/apps/desktop/tests/e2e run test:desktop:core
 
 # ── 聚合 ────────────────────────────────────────────────────
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 changelog_update = true
 dependencies_update = true
+git_only = true
 git_release_enable = false
 git_tag_enable = false
 pr_branch_prefix = "release-plz/"


### PR DESCRIPTION
## Summary
- align repository release automation, SemVer checks, and repository-level changelog/version messaging with the current template baseline
- fix backend/platform maintenance and verification commands, including migration helpers, process utilities, platform inventory commands, and stale path/package references
- clarify repository docs and onboarding so template versioning follows repository tags/releases and desktop/Tauri stays outside the default backend CI flow

## Testing
- locally verified backend/platform commands including `just doctor`, `just validate-platform`, `just validate-state strict`, `just validate-workflows strict`, `just verify-generated`, `just semver-check`, `just drift-check`, `just sdk-drift-check`, `just migrate-status`, `just sops-validate`, `just ps`, and `just ports`