### PR TITLE
fix(readme): refresh template version badge after tag bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Backend-in-Rust Template and Reference Architecture
 
-[![Template version](https://img.shields.io/github/v/tag/openclosed-org/axum-harness?sort=semver&label=template%20version)](https://github.com/openclosed-org/axum-harness/tags)
+[![Template version](https://img.shields.io/github/v/tag/openclosed-org/axum-harness?sort=semver&label=template%20version&cacheSeconds=60)](https://github.com/openclosed-org/axum-harness/tags)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-blue)](./CHANGELOG.md)
 [![Release notes](https://img.shields.io/badge/release%20notes-GitHub-blueviolet)](https://github.com/openclosed-org/axum-harness/releases)
 


### PR DESCRIPTION
## Summary
- push the existing `v0.2.0` repository tag to GitHub so the template version badge has a real remote tag to resolve
- refresh the README badge URL with a short cache window so Shields stops serving the stale `no tags found` result after tag bootstrap
- clean up obsolete working branches left behind by the closed conflicted PR and the temporary clean replacement branch

## Notes
- no behavior or code-path changes; this is a repository metadata and documentation display fix