### PR TITLE
fix(release): scope release-pr to repo anchor

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -148,6 +148,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@1800853f2578f8c34492ec76154caef8e163fbca
+
+      - name: Install release-plz
+        run: |
+          cargo binstall \
+            release-plz@0.3.157 \
+            --force \
+            --strategies=crate-meta-data,compile \
+            --no-confirm
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Render release-plz config
         env:
           RELEASE_TAG_TEMPLATE: ${{ needs.release-line.outputs.release_tag_template }}
@@ -155,13 +171,17 @@ jobs:
           RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > .github/release-plz.runtime.toml
 
       - name: Run release-plz release-pr
-        uses: release-plz/action@v0.5
-        with:
-          command: release-pr
-          manifest_path: tools/repo-release/Cargo.toml
-          config: .github/release-plz.runtime.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release-plz release-pr \
+            --git-token "${GITHUB_TOKEN}" \
+            --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --manifest-path tools/repo-release/Cargo.toml \
+            --package axum-harness \
+            --forge github \
+            --config .github/release-plz.runtime.toml \
+            -o json
 
   release:
     name: GitHub Release
@@ -179,6 +199,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@1800853f2578f8c34492ec76154caef8e163fbca
+
+      - name: Install release-plz
+        run: |
+          cargo binstall \
+            release-plz@0.3.157 \
+            --force \
+            --strategies=crate-meta-data,compile \
+            --no-confirm
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Render release-plz config
         env:
           RELEASE_TAG_TEMPLATE: ${{ needs.release-line.outputs.release_tag_template }}
@@ -186,11 +222,14 @@ jobs:
           RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > .github/release-plz.runtime.toml
 
       - name: Run release-plz release
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: tools/repo-release/Cargo.toml
-          config: .github/release-plz.runtime.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          release-plz release \
+            --git-token "${GITHUB_TOKEN}" \
+            --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --manifest-path tools/repo-release/Cargo.toml \
+            --forge github \
+            --config .github/release-plz.runtime.toml \
+            -o json


### PR DESCRIPTION
## Summary
- replace the release-plz action steps with explicit CLI installation and invocation
- scope the release-pr workflow to the repository release anchor package `axum-harness`
- keep the repository release flow focused on the repo-level manifest instead of scanning internal workspace crates