### PR TITLE
fix(release): keep release-plz worktree clean

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -168,14 +168,15 @@ jobs:
         env:
           RELEASE_TAG_TEMPLATE: ${{ needs.release-line.outputs.release_tag_template }}
         run: |
-          RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > .github/release-plz.runtime.toml
+          mkdir -p "$RUNNER_TEMP/release-plz"
+          RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > "$RUNNER_TEMP/release-plz/release-plz.runtime.toml"
 
       - name: Extract baseline release manifest
         env:
           BASELINE_TAG: ${{ needs.release-line.outputs.baseline_tag }}
         run: |
-          mkdir -p .github/release-plz-baseline
-          git show "${BASELINE_TAG}:tools/repo-release/Cargo.toml" > .github/release-plz-baseline/Cargo.toml
+          mkdir -p "$RUNNER_TEMP/release-plz/baseline"
+          git show "${BASELINE_TAG}:tools/repo-release/Cargo.toml" > "$RUNNER_TEMP/release-plz/baseline/Cargo.toml"
 
       - name: Run release-plz release-pr
         env:
@@ -185,10 +186,10 @@ jobs:
             --git-token "${GITHUB_TOKEN}" \
             --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
             --manifest-path tools/repo-release/Cargo.toml \
-            --registry-manifest-path .github/release-plz-baseline/Cargo.toml \
+            --registry-manifest-path "$RUNNER_TEMP/release-plz/baseline/Cargo.toml" \
             --package axum-harness \
             --forge github \
-            --config .github/release-plz.runtime.toml \
+            --config "$RUNNER_TEMP/release-plz/release-plz.runtime.toml" \
             -o json
 
   release:
@@ -227,14 +228,15 @@ jobs:
         env:
           RELEASE_TAG_TEMPLATE: ${{ needs.release-line.outputs.release_tag_template }}
         run: |
-          RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > .github/release-plz.runtime.toml
+          mkdir -p "$RUNNER_TEMP/release-plz"
+          RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > "$RUNNER_TEMP/release-plz/release-plz.runtime.toml"
 
       - name: Extract baseline release manifest
         env:
           BASELINE_TAG: ${{ needs.release-line.outputs.baseline_tag }}
         run: |
-          mkdir -p .github/release-plz-baseline
-          git show "${BASELINE_TAG}:tools/repo-release/Cargo.toml" > .github/release-plz-baseline/Cargo.toml
+          mkdir -p "$RUNNER_TEMP/release-plz/baseline"
+          git show "${BASELINE_TAG}:tools/repo-release/Cargo.toml" > "$RUNNER_TEMP/release-plz/baseline/Cargo.toml"
 
       - name: Run release-plz release
         env:
@@ -246,5 +248,5 @@ jobs:
             --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
             --manifest-path tools/repo-release/Cargo.toml \
             --forge github \
-            --config .github/release-plz.runtime.toml \
+            --config "$RUNNER_TEMP/release-plz/release-plz.runtime.toml" \
             -o json

--- a/.gitignore
+++ b/.gitignore
@@ -63,10 +63,36 @@ msedgedriver.exe
 
 # --- Tauri generated ---
 apps/desktop/src-tauri/target/
-apps/desktop/src-tauri/gen/
+apps/desktop/src-tauri/gen/*
+!apps/desktop/src-tauri/gen/schemas/
+!apps/desktop/src-tauri/gen/schemas/acl-manifests.json
+!apps/desktop/src-tauri/gen/schemas/capabilities.json
+!apps/desktop/src-tauri/gen/schemas/desktop-schema.json
+!apps/desktop/src-tauri/gen/schemas/macOS-schema.json
 
 # ts-rs intermediate output
-packages/contracts/*/bindings/
+packages/contracts/*/bindings/**
+!packages/contracts/api/bindings/
+!packages/contracts/api/bindings/api/
+!packages/contracts/api/bindings/api/AdminDashboardStats.ts
+!packages/contracts/api/bindings/api/AgentConfig.ts
+!packages/contracts/api/bindings/api/ChatMessage.ts
+!packages/contracts/api/bindings/api/HealthResponse.ts
+!packages/contracts/api/bindings/api/InitTenantRequest.ts
+!packages/contracts/api/bindings/api/InitTenantResponse.ts
+!packages/contracts/api/bindings/api/ToolCall.ts
+!packages/contracts/api/bindings/serde_json/
+!packages/contracts/api/bindings/serde_json/JsonValue.ts
+!packages/contracts/auth/bindings/
+!packages/contracts/auth/bindings/auth/
+!packages/contracts/auth/bindings/auth/OAuthCallback.ts
+!packages/contracts/auth/bindings/auth/TokenPair.ts
+!packages/contracts/auth/bindings/auth/UserProfile.ts
+!packages/contracts/auth/bindings/auth/UserSession.ts
+!packages/contracts/events/bindings/
+!packages/contracts/events/bindings/events/
+!packages/contracts/events/bindings/events/TenantCreated.ts
+!packages/contracts/events/bindings/events/TenantMemberAdded.ts
 
 # --- Local tool binaries ---
 tools/nats/nats-server


### PR DESCRIPTION
## Summary
- keep generated release-plz runtime files under RUNNER_TEMP instead of the repository checkout
- keep tracked Tauri schema and ts-rs binding files from being classified as ignored files
- preserve ignored intermediate generated output outside the explicitly tracked files

## Validation
- gh workflow view release-plz.yml --yaml >/dev/null
- git ls-files -ci --exclude-standard
- release-plz update --manifest-path tools/repo-release/Cargo.toml --registry-manifest-path <baseline>/Cargo.toml --package axum-harness --config <rendered-config> --allow-dirty -vv