### PR TITLE
docs(agent): strengthen bug-fix protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,33 @@ Only split when directory, responsibility, or verification boundaries genuinely 
 ## 6. Global Hard Constraints
 
 1. Read before changing; evidence before judgment; search before guessing.
-2. Prioritize minimal closed loops; no unrelated refactoring.
-3. Verification that wasn't executed cannot be claimed as passed.
-4. Mark uncertainty explicitly; never dress up guesses as conclusions.
-5. "Solving" by deleting, skipping, swallowing errors, or faking success is forbidden.
-6. Generated artifact directories are read-only; modify the source and regenerate.
-7. Escalate risk when: the change conflicts with architecture ADRs, spans multiple core directories, changes critical dependencies, or involves 4+ subagents with complex dependencies.
+2. Prioritize the smallest causal closed loop: identify the violated invariant and root-cause boundary first, then make the minimal complete repair; no unrelated refactoring.
+3. Passing tests are evidence, not the goal. The goal is restored behavior, restored invariants, and executable verification that would fail without the fix.
+4. Verification that wasn't executed cannot be claimed as passed.
+5. Mark uncertainty explicitly; never dress up guesses as conclusions.
+6. "Solving" by deleting, skipping, weakening validation, swallowing errors, bypassing gates, or faking success is forbidden.
+7. Generated artifact directories are read-only; modify the source and regenerate.
+8. Escalate risk when: the change conflicts with architecture ADRs, spans multiple core directories, changes critical dependencies, affects distributed semantics, or involves 4+ subagents with complex dependencies.
+
+## 7. Bug Fix and Repair Protocol
+
+Use this protocol for bug reports, failing gates, regressions, and suspicious behavior:
+
+1. Reproduce or localize the failure with code, schema, validator, gate, script, or command-output evidence when feasible.
+2. Identify the violated invariant, not only the failing line, failing test, or surface symptom.
+3. Determine the causal boundary: contract, service, server, worker, platform, infra, app, or cross-boundary.
+4. Fix the smallest causal closed loop that restores the invariant.
+5. Add or update regression verification at the same semantic level as the bug.
+6. Run the relevant gates; state explicitly when a gate was not run.
+7. If only a tactical fix is safe in the current turn, state the residual architectural or operational risk explicitly.
+
+Bug-fix shortcuts are forbidden:
+
+1. Do not delete, skip, or weaken tests to pass.
+2. Do not swallow errors or replace failures with defaults unless the domain explicitly defines that fallback.
+3. Do not edit generated artifacts directly.
+4. Do not move logic across ownership boundaries to avoid fixing the owner.
+5. Do not satisfy a gate by bypassing the behavior the gate was meant to protect.
+6. Do not optimize for the smallest diff; optimize for the smallest correct causal repair.
+
+Escalate instead of patching locally when a bug affects distributed semantics, including consistency, idempotency, retry, checkpoint/replay, event ordering, outbox delivery, projection rebuildability, ownership, authorization, secrets, topology, or contract compatibility.


### PR DESCRIPTION
## Summary
- strengthen the global hard constraints around causal repair and verification
- add an explicit bug-fix and repair protocol for failing gates, regressions, and suspicious behavior
- document forbidden bug-fix shortcuts and distributed-semantics escalation triggers