### PR TITLE
Prepare v0.3.0 template control-plane release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,54 +1,50 @@
 # AGENTS.md
 
 > Thin coordination protocol for this repository. All agents read this first.
-> This file contains cross-cutting rules, constraints, and indexes — not descriptions of current state.
-> Current-state guidance lives in `docs/README.md`; machine-readable rules live in `agent/codemap.yml`.
+> This file contains stable cross-cutting rules only. Harness philosophy lives in `docs/architecture/harness-philosophy.md`; current-state guidance lives in `docs/README.md`.
 
 ## 1. Language Preference
 
-Communication **MUST** be Chinese
+Communication **MUST** be Chinese.
 
-Code, commands, config keys, logs, and protocol fields always remain in their original language.
+Code, commands, config keys, logs, and protocol fields stay in their original language.
 
 ## 2. Default Reading Order
 
 Backend tasks:
 
 1. `AGENTS.md`
-2. `agent/codemap.yml`
-3. `agent/manifests/routing-rules.yml`
-4. `agent/manifests/gate-matrix.yml`
-5. `docs/operations/counter-service-reference-chain.md`
+2. `docs/architecture/harness-philosophy.md`
+3. `agent/codemap.yml`
+4. `agent/manifests/routing-rules.yml`
+5. `agent/manifests/gate-matrix.yml`
 
 Documentation / audit tasks: also read `docs/README.md`.
 
-## 3. Source-of-Truth Priority
+## 3. Truth Hierarchy
 
-When determining the current state, gather evidence in this order:
+When determining current state, gather evidence in this order:
 
-1. Code, schemas, validators, gates, scripts
-2. `agent/codemap.yml`
-3. `agent/manifests/routing-rules.yml`
-4. `agent/manifests/gate-matrix.yml`
-5. `docs/operations/counter-service-reference-chain.md`
-6. `docs/adr/**` and `.agents/skills/*/SKILL.md`
+1. code, schemas, validators, tests, gates, scripts, and command output
+2. generated artifacts only when produced from current sources and checked for drift
+3. `platform/model/**` and `services/*/model.yaml`
+4. `agent/**` manifests
+5. prose documentation
 
 Hard rules:
 
-1. When docs conflict with code, trust code and executable verification.
+1. When docs or YAML conflict with executable sources, trust executable sources.
 2. Never infer a file or module exists solely from target-state documentation.
-3. Conclusions about the current state must point to a real file, directory, or command output.
+3. YAML declarations can describe intent; they do not prove semantic correctness.
+4. `declared`, `checked`, `tested`, and `proven` claims must cite executable evidence when raised above `declared`.
 
-## 4. Planner Responsibilities
+## 4. Routing
 
-**Does**: understand goals, audit directories, dispatch subagents per `routing-rules.yml`, advance changes in dependency order, converge results.
-**Does NOT**: design non-existent modules, merge multi-domain patches into one, replace gates/scripts with prose.
+Full mapping lives in `agent/manifests/routing-rules.yml`.
 
-## 5. Routing
+Quick reference:
 
-Full mapping lives in `agent/manifests/routing-rules.yml`. Quick reference:
-
-| Path                                                            | Subagent           |
+| Path                                                            | Primary owner      |
 | --------------------------------------------------------------- | ------------------ |
 | `platform/model/**`, `platform/schema/**`, `infra/**`, `ops/**` | platform-ops-agent |
 | `packages/contracts/**`, `docs/contracts/**`                    | contract-agent     |
@@ -56,41 +52,41 @@ Full mapping lives in `agent/manifests/routing-rules.yml`. Quick reference:
 | `servers/**`                                                    | server-agent       |
 | `workers/**`                                                    | worker-agent       |
 | `apps/**`, `packages/ui/**`                                     | app-shell-agent    |
-| `AGENTS.md`, `agent/**`, root config                            | planner            |
+| `AGENTS.md`, `agent/**`, root config, `docs/architecture/**`    | planner            |
 
-Multi-domain dispatch order: platform-ops → contract → service → server/worker → app-shell → final verification.
-Only split when directory, responsibility, or verification boundaries genuinely differ.
+Multi-domain dispatch order: platform-ops -> contract -> service -> server/worker -> app-shell -> verification.
+
+Only split work when directory, responsibility, or verification boundaries genuinely differ.
+
+## 5. Gate Selection
+
+Gate selection is based on changed paths, risk category, and evidence level, not subagent identity.
+
+Use `agent/manifests/gate-matrix.yml` to choose advisory, guardrail, or invariant gates.
+
+Default backend-core development should prefer path-scoped guardrails and `just verify-backend-primary`. `just verify` is the default repo-wide backend-core gate when broader confidence is needed, not a requirement that every change run every platform, frontend, desktop, production, or release gate.
+
+P0 invariants and release readiness require executable evidence. Metadata alone is never sufficient.
 
 ## 6. Global Hard Constraints
 
 1. Read before changing; evidence before judgment; search before guessing.
-2. Prioritize the smallest causal closed loop: identify the violated invariant and root-cause boundary first, then make the minimal complete repair; no unrelated refactoring.
-3. Passing tests are evidence, not the goal. The goal is restored behavior, restored invariants, and executable verification that would fail without the fix.
-4. Verification that wasn't executed cannot be claimed as passed.
+2. Fix the smallest causal closed loop that restores the violated invariant.
+3. Passing tests are evidence, not the goal; restored behavior and restored invariants are the goal.
+4. Verification that was not executed cannot be claimed as passed.
 5. Mark uncertainty explicitly; never dress up guesses as conclusions.
-6. "Solving" by deleting, skipping, weakening validation, swallowing errors, bypassing gates, or faking success is forbidden.
+6. Do not solve by deleting, skipping, weakening validation, swallowing errors, bypassing gates, or faking success.
 7. Generated artifact directories are read-only; modify the source and regenerate.
-8. Escalate risk when: the change conflicts with architecture ADRs, spans multiple core directories, changes critical dependencies, affects distributed semantics, or involves 4+ subagents with complex dependencies.
+8. Escalate risk when a change affects distributed semantics, authorization, secrets, topology, contract compatibility, or release correctness.
 
-## 7. Bug Fix and Repair Protocol
+## 7. Bug Fix Protocol
 
-Use this protocol for bug reports, failing gates, regressions, and suspicious behavior:
+For bug reports, failing gates, regressions, and suspicious behavior:
 
 1. Reproduce or localize the failure with code, schema, validator, gate, script, or command-output evidence when feasible.
-2. Identify the violated invariant, not only the failing line, failing test, or surface symptom.
+2. Identify the violated invariant, not only the failing line or symptom.
 3. Determine the causal boundary: contract, service, server, worker, platform, infra, app, or cross-boundary.
-4. Fix the smallest causal closed loop that restores the invariant.
+4. Make the minimal complete repair at that boundary.
 5. Add or update regression verification at the same semantic level as the bug.
-6. Run the relevant gates; state explicitly when a gate was not run.
-7. If only a tactical fix is safe in the current turn, state the residual architectural or operational risk explicitly.
-
-Bug-fix shortcuts are forbidden:
-
-1. Do not delete, skip, or weaken tests to pass.
-2. Do not swallow errors or replace failures with defaults unless the domain explicitly defines that fallback.
-3. Do not edit generated artifacts directly.
-4. Do not move logic across ownership boundaries to avoid fixing the owner.
-5. Do not satisfy a gate by bypassing the behavior the gate was meant to protect.
-6. Do not optimize for the smallest diff; optimize for the smallest correct causal repair.
-
-Escalate instead of patching locally when a bug affects distributed semantics, including consistency, idempotency, retry, checkpoint/replay, event ordering, outbox delivery, projection rebuildability, ownership, authorization, secrets, topology, or contract compatibility.
+6. Run relevant gates and state explicitly when a gate was not run.
+7. If only a tactical fix is safe, state the residual risk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,42 @@ Preferred release views:
 
 ## Unreleased
 
+## v0.3.0 - 2026-04-27
+
+### Added
+
+- Added a `backend-core` template audit path so maintainers and adopters can prove the root command surface no longer depends on optional app-shell directories.
+- Added `docs/architecture/harness-philosophy.md` to define harness boundaries, truth hierarchy, evidence levels, metadata limits, and gate strength.
+- Added configurable release tag strategy inputs so maintainers can override tag template, tag glob, and bootstrap baseline without editing tracked files.
+
 ### Changed
 
-- Aligned repository release automation and SemVer checks with the latest real template baseline instead of the old hard-coded `v0.1.x` line.
-- Clarified in README and maintainer docs that repository tags are the template version contract and that desktop/Tauri validation is local-only, not part of the default backend CI admission flow.
-- Reworked Quick Start and local development guidance to emphasize the backend-first path and remove stale or misleading command examples.
-- Fixed multiple broken or outdated `just` recipes in backend/platform workflows, including SemVer baseline detection, platform inventory commands, migration helpers, process utilities, and stale package/path references.
-- Added a repository-level changelog entry point so release notes have an explicit home in the template itself.
-- Replaced the hard-coded `axum-harness-v*` release lane with a runtime-configurable tag strategy so template consumers can control tag naming, tag matching, and bootstrap baselines through CI inputs or repository variables.
+- Decoupled optional web, desktop, mobile, and UI shell surfaces from the default backend-core template contract.
+- Reworked root `just`, `moon`, and shared scripts so backend-core commands do not require SvelteKit, Tauri, `apps/**`, or `packages/ui/**` by default.
+- Reframed `agent/codemap.yml` as a compact navigation map instead of a full system model or heavyweight architecture constitution.
+- Rebuilt `agent/manifests/gate-matrix.yml` around changed paths, risk categories, and evidence levels instead of subagent identity.
+- Clarified that `services/<name>/model.yaml`, `platform/model/**`, and agent YAML declarations are semantic summaries or metadata, not formal proof of system correctness.
+- Clarified that `advisory`, `guardrail`, and `invariant` gates have different blocking strength, and that invariant gates are reserved for P0 correctness and release readiness.
+- Clarified that `just verify-backend-primary` is the default backend-core guardrail and `just verify` is a broader repo-wide guardrail, not an automatic requirement to run every platform, frontend, desktop, production, or release gate.
+- Strengthened the root agent protocol around bug fixes: reproduce or localize failures, identify violated invariants, make minimal causal repairs, add regression evidence, and never claim unrun gates as passed.
 
-### Notes
+### Fixed
 
-- The legacy `v0.2.0` tag was retired because it pointed at an obsolete pre-template workspace layout and polluted repository-level release automation.
-- GitHub Releases remains the best public view for generated release notes once release automation runs.
+- Fixed release-plz workflow scoping so release PRs are prepared from the repository-level release anchor instead of unrelated workspace packages.
+- Fixed release baseline comparison to use the active template tag line instead of stale hard-coded assumptions.
+- Fixed release-plz worktree hygiene so generated release state does not leave the repository dirty during automation.
+- Fixed backend-core root entrypoint drift by removing stale app-shell command exposure from shared validation and development lanes.
+
+### Documentation
+
+- Updated README, CONTRIBUTING, docs index, and agent docs to describe path/risk/evidence-based gate selection.
+- Documented that metadata-only changes can raise a claim to `declared`, but `checked`, `tested`, and `proven` claims require executable evidence such as validators, tests, gates, or command output.
+
+### Migration Notes
+
+- Use `just verify-backend-primary` for ordinary backend-core development and add path-specific guardrails from `agent/manifests/gate-matrix.yml` when contracts, platform model, workers, topology, delivery, or release risk is involved.
+- Use `bun run scripts/run-scoped-gates.ts --list` as compatibility guidance only; it no longer runs heavyweight gates just because a subagent handled a change.
+- Treat app-shell validation as local to retained app shells. Root backend-core admission should remain independent from optional frontend and desktop surfaces.
 
 ## v0.2.0 - 2026-04-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,23 +73,19 @@ Desktop/Tauri is not part of the default CI contract for this repository. If you
 Common commands:
 
 ```bash
-just fmt
-just lint
-just typecheck
-just test
-just validate-platform
-just validate-state strict
-just validate-workflows strict
-just verify-replay strict
-just verify-counter-delivery strict
+just verify-backend-primary
+just test-backend-primary
+just boundary-check
+just contracts-check strict
 just verify
 ```
 
-Agent- and domain-specific validation is also available:
+Heavier platform, replay, delivery, and release gates are selected by changed paths, risk, and evidence level. Do not run or require them for every ordinary backend-core change.
+
+Gate-selection guidance is available here:
 
 ```bash
-just gate-scoped AGENT=service-agent
-bun run scripts/run-scoped-gates.ts service-agent
+bun run scripts/run-scoped-gates.ts --list
 ```
 
 Only claim checks passed if you actually ran them.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "axum-harness"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "backtrace"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use it as a strong starting point, not as proof that every pattern here is alrea
 - **Platform model as truth source** — `platform/model/*` declares deployables, workflows, topologies, resources, environments. No implicit infrastructure.
 - **Single VPS to K3s** — `platform/model/topologies/*.yaml` defines the deployment shape. Same binary, different topology.
 - **SOPS + Flux GitOps** — Backend secrets flow through SOPS/Kustomize/Flux, not `.env` files. `just sops-run <deployable>` injects env vars locally; Flux reconciles in-cluster.
-- **Multi-agent AI harness** — 8 specialized agents (planner, platform-ops, contract, service, server, worker, app-shell) with routing rules, scoped gates, and boundary checks.
+- **Multi-agent AI harness** — 8 specialized agents (planner, platform-ops, contract, service, server, worker, app-shell) with routing rules, path/risk-based gates, and boundary checks.
 
 ## Versioning and Changelog
 
@@ -187,17 +187,19 @@ For backend-only derived projects, `just template-init backend-core dry-run` sho
 
 This repository has a built-in multi-agent collaboration protocol.
 
-- `AGENTS.md` — master protocol: reading order, truth source hierarchy, routing rules, global constraints
-- `agent/codemap.yml` — module boundaries, dependency rules, anti-patterns, required files per entity type
+- `AGENTS.md` — thin protocol: reading order, truth hierarchy, routing, gate-selection rules, global constraints
+- `docs/architecture/harness-philosophy.md` — harness boundaries, metadata limits, evidence levels, and gate strength
+- `agent/codemap.yml` — compact navigation map for boundaries, source-of-truth pointers, generated-readonly paths, anti-patterns, and modification order
 - `agent/manifests/routing-rules.yml` — path → subagent dispatch map
-- `agent/manifests/gate-matrix.yml` — subagent → gate mapping (typecheck, boundary, drift, replay, resilience)
+- `agent/manifests/gate-matrix.yml` — changed paths / risk / evidence level → advisory, guardrail, or invariant gates
 
-Gates enforce architectural boundaries. Every agent dispatch ends with scoped verification:
+Gates are selected from changed paths, risk, and evidence level, not from subagent identity:
 
 ```bash
 bun run scripts/route-task.ts              # Route a task to the right subagent
-bun run scripts/run-scoped-gates.ts <agent> # Run gates for a specific agent
-just verify                                 # Total verification (final gate)
+bun run scripts/run-scoped-gates.ts --list  # Show gate-selection guidance
+just verify-backend-primary                 # Default backend-core guardrail
+just verify                                 # Broader repo-wide guardrail when needed
 ```
 
 More repository policy and documentation-boundary details live in `docs/README.md`.

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,20 +1,20 @@
 # Agent Harness
 
-`agent/` 只保留最小的 agent 协作真理源，不承载业务逻辑、模板、checklist 或流程散文。
+`agent/` 只保留最小的 agent 协作控制面，不承载业务逻辑、完整系统模型或形式化证明。
 
 ## 目录职责
 
 1. `codemap.yml`
-   负责模块边界、写权限、依赖方向、分布式硬约束与必填语义。
+   负责目录边界、写权限、依赖方向、生成物只读位置、反模式与修改顺序。
 2. `manifests/routing-rules.yml`
    负责 touched paths 到 subagent 的路由与派发顺序。
 3. `manifests/gate-matrix.yml`
-   负责 subagent 对应的 scoped gates 与最终总验证。
+   负责按 changed paths、risk category、evidence level 选择 advisory、guardrail、invariant gates。
 
 ## 使用顺序
 
 1. 先读根级 `AGENTS.md`。
-2. 再读 `agent/codemap.yml`，确认边界、禁止事项与 required fields。
+2. 再读 `docs/architecture/harness-philosophy.md` 和 `agent/codemap.yml`，确认 harness 边界、导航地图与禁止事项。
 3. 最后根据 `routing-rules.yml` 和 `gate-matrix.yml` 决定派发与验证。
 
 ## 说明
@@ -22,3 +22,4 @@
 1. 详细 subagent 行为定义仍在 `.agents/skills/*/SKILL.md`。
 2. 参考实现与真实开发模式优先从现有 `services/*`、`workers/*`、`servers/*` 和 `packages/contracts/*` 获取。
 3. 如果 `agent/` 文档与代码冲突，以代码和可执行验证结果为准。
+4. YAML 只能声明 intent 或 summary；不能单独证明系统语义正确。

--- a/agent/codemap.yml
+++ b/agent/codemap.yml
@@ -1,280 +1,234 @@
-version: 2
+version: 3
+
 repo:
   name: axum-harness
   mode: agent-first-distributed-harness
   purpose: >
-    为后端优先的 agent 协作提供稳定目录边界、真理源分层与默认参考锚点，
-    让后续修改优先沿 `counter-service` reference chain 与既有 gate/tooling 推进。
+    Provide a compact navigation map for agent collaboration: stable directory
+    boundaries, source-of-truth pointers, generated-readonly locations,
+    anti-patterns, and modification order.
 
-notes: >
-  本文档描述当前稳定边界与默认开发轨道，不把未落地模块写成既成事实。
-  service 的细粒度分布式语义归属 services/<name>/model.yaml，
-  platform/model/* 只保留平台级元数据、全局规则、deployable、workflow、topology、resource、environment。
+notes:
+  - codemap.yml is a map, not a complete system model.
+  - services/<name>/model.yaml is a service semantic summary, not proof.
+  - platform/model/** carries platform-level metadata and global shape, not service-local formal semantics.
+  - Claims above declared require executable evidence from tests, gates, validators, or command output.
 
-principles:
-  - id: schema-before-model
-    rule: 需要新增语义表达时，先扩展 platform/schema，再修改 model。
-  - id: platform-model-first
-    rule: 平台级能力先修改 platform/model，再考虑 infra 与生成物。
-  - id: service-local-semantics
-    rule: service 的 owns_entities、commands、events、queries、consistency 等细粒度语义写在 services/<name>/model.yaml。
-  - id: contracts-first
-    rule: HTTP/Event/RPC/DTO/ErrorCode 变化先修改 packages/contracts。
-  - id: shared-contract-boundary
-    rule: 跨进程、跨 deployable、HTTP、消息或 event_outbox 边界的 DTO/Event/ErrorCode 必须进入 packages/contracts；service-local 类型只能用于 crate 内部编排。
-  - id: canonical-outbox-path
-    rule: 领域事件的 canonical relay path 是 event_outbox -> workers/outbox-relay -> EventBus/NATS -> consumers；runtime PubSub 只能作为兼容镜像或按需基础设施能力。
-  - id: services-are-libraries
-    rule: services 是能力边界与状态边界，不承载进程入口。
-  - id: workers-are-first-class
-    rule: 所有异步执行逻辑必须进入 workers，并显式声明幂等、重试、checkpoint/replay。
-  - id: vendor-in-adapters-only
-    rule: vendor 依赖只能出现在 adapters 或 *-adapters 目录。
-  - id: generated-readonly
-    rule: 所有生成物目录只读，不允许手工维护。
-  - id: topology-no-semantic-change
-    rule: topology 只能改变承载形态，不得改变状态语义。
-  - id: single-owner-per-entity
-    rule: 每个核心实体必须存在唯一 owner service。
-  - id: projection-must-rebuild
-    rule: projection 必须可删可重建。
-  - id: workflow-for-long-transactions
-    rule: 跨 service 多步状态变更必须 workflow 化。
+truth_hierarchy:
+  - code, schemas, validators, tests, gates, scripts, and command output
+  - generated artifacts only when produced from current sources and checked for drift
+  - platform/model/** and services/*/model.yaml
+  - agent manifests
+  - prose documentation
+
+source_of_truth:
+  contracts:
+    paths:
+      - packages/contracts/**
+    note: External DTO, event, RPC, and error shapes live here before implementation changes.
+  platform_shape:
+    paths:
+      - platform/schema/**
+      - platform/model/**
+      - platform/validators/**
+      - platform/generators/**
+    note: Platform-level metadata, schemas, validators, generators, topology, resources, deployables, and global policy.
+  service_semantics:
+    paths:
+      - services/*/model.yaml
+      - services/**/src/**
+      - services/**/tests/**
+    note: Service-local ownership, commands, events, queries, policies, consistency summaries, and executable behavior.
+  runtime_entrypoints:
+    paths:
+      - servers/**
+      - workers/**
+    note: Servers adapt synchronous protocols; workers handle async execution, projectors, schedulers, replay, and recovery.
+  verification:
+    paths:
+      - verification/**
+      - scripts/**
+      - justfiles/**
+      - moon.yml
+    note: Evidence comes from executable checks, not metadata declarations.
 
 layers:
   - name: root
     paths:
-      - ".mise.toml"
-      - "justfile"
-      - "moon.yml"
-      - "Cargo.toml"
-      - "package.json"
-      - ".github/**"
-    role: 根配置与入口层
+      - .mise.toml
+      - justfile
+      - justfiles/**
+      - moon.yml
+      - Cargo.toml
+      - package.json
+      - .github/**
+    role: Root configuration, shared commands, and CI wiring.
 
   - name: agent
     paths:
-      - "agent/**"
-    role: agent 规则、模板、决策树、反模式、交接协议
+      - AGENTS.md
+      - agent/**
+      - .agents/**
+    role: Agent coordination, routing, gate selection guidance, and skills.
 
-  - name: platform-model
+  - name: platform
     paths:
-      - "platform/schema/**"
-      - "platform/model/**"
-      - "platform/generators/**"
-      - "platform/validators/**"
-      - "platform/catalog/**"
-    role: 平台控制面、schema、validator、generator、catalog
-    notes: >
-      platform/model/* 只保留平台级元数据、全局规则、deployable、workflow、topology、resource、environment。
+      - platform/schema/**
+      - platform/model/**
+      - platform/generators/**
+      - platform/validators/**
+      - platform/catalog/**
+    role: Platform control plane, schema, validators, generators, and generated catalog.
 
-  - name: apps
+  - name: contracts
     paths:
-      - "apps/**"
-    role: Web/Desktop/Mobile 客户端壳层
-
-  - name: servers
-    paths:
-      - "servers/**"
-    role: 同步请求入口层
+      - packages/contracts/**
+      - docs/contracts/**
+    role: Shared protocol and generated contract source-of-truth.
 
   - name: services
     paths:
-      - "services/**"
-    role: 业务能力与状态边界层
-    notes: >
-      每个 service 目录必须包含 model.yaml，由 service-agent 负责维护 service-local distributed semantics。
+      - services/**
+    role: Business capabilities and state boundaries as pure libraries.
+
+  - name: servers
+    paths:
+      - servers/**
+    role: Synchronous request entrypoints and protocol adaptation.
 
   - name: workers
     paths:
-      - "workers/**"
-    role: 异步执行、projection、replay、恢复层
+      - workers/**
+    role: Async execution, outbox relay, projection, scheduling, replay, and recovery.
 
-  - name: packages
+  - name: apps
     paths:
-      - "packages/kernel/**"
-      - "packages/platform/**"
-      - "packages/contracts/**"
-      - "packages/sdk/**"
-      - "packages/runtime/**"
-      - "packages/authn/**"
-      - "packages/authz/**"
-      - "packages/data/**"
-      - "packages/data-traits/**"
-      - "packages/data-adapters/**"
-      - "packages/messaging/**"
-      - "packages/cache/**"
-      - "packages/cache-traits/**"
-      - "packages/cache-adapters/**"
-      - "packages/storage/**"
-      - "packages/storage-traits/**"
-      - "packages/storage-adapters/**"
-      - "packages/observability/**"
-      - "packages/security/**"
-      - "packages/ui/**"
-      - "packages/devx/**"
-      - "packages/workspace-hack/**"
-    role: 共享抽象、traits、adapters、sdk、tooling
+      - apps/**
+      - packages/ui/**
+    role: Optional web, desktop, mobile, and shared UI shells.
 
-  - name: infra
+  - name: shared-packages
     paths:
-      - "infra/**"
-    role: 基础设施声明与交付层
+      - packages/kernel/**
+      - packages/platform/**
+      - packages/runtime/**
+      - packages/sdk/**
+      - packages/authn/**
+      - packages/authz/**
+      - packages/data/**
+      - packages/data-traits/**
+      - packages/data-adapters/**
+      - packages/messaging/**
+      - packages/cache/**
+      - packages/cache-traits/**
+      - packages/cache-adapters/**
+      - packages/storage/**
+      - packages/storage-traits/**
+      - packages/storage-adapters/**
+      - packages/observability/**
+      - packages/security/**
+      - packages/devx/**
+      - packages/workspace-hack/**
+    role: Shared abstractions, runtime libraries, adapters, SDKs, security, observability, and tooling.
 
-  - name: ops
+  - name: infra-ops
     paths:
-      - "ops/**"
-    role: 运维执行层
+      - infra/**
+      - ops/**
+    role: Infrastructure declarations, local dependencies, delivery manifests, and operations runbooks.
 
   - name: verification
     paths:
-      - "verification/**"
-    role: 跨层验证、compatibility、replay、golden 层
+      - verification/**
+      - fixtures/**
+      - tools/**
+    role: Cross-layer verification, fixtures, diagnostics, replay, contract, topology, and resilience evidence.
 
   - name: docs
     paths:
-      - "docs/**"
-    role: ADR、架构和运维文档层
+      - docs/**
+    role: Durable architecture, operations, adoption, governance, and archive documents.
 
-  - name: fixtures
-    paths:
-      - "fixtures/**"
-    role: 测试数据、事件样例、authz tuples、demo 数据
+generated_readonly:
+  - infra/kubernetes/rendered/**
+  - docs/generated/**
+  - platform/catalog/**
+  - packages/contracts/generated/**
 
-  - name: tools
-    paths:
-      - "tools/**"
-    role: 本地工具与诊断层
-
-reference_modules:
-  services:
-    - name: auth-service
-      path: services/auth-service
-      role: 认证服务占位
-      status: stub
-    - name: counter-service
-      path: services/counter-service
-      role: 默认后端参考锚点，承载业务主链与工程横切链的最小参考样例
-      status: reference
-    - name: indexing-service
-      path: services/indexing-service
-      role: 索引服务规划占位，仅保留语义边界，不参与 workspace 或 release-plz
-      status: planned
-    - name: tenant
-      path: services/tenant-service
-      role: 多租户、多实体、workflow、补偿样例
-      status: reference
-    - name: user-service
-      path: services/user-service
-      role: 用户画像服务，跨服务读 tenant-membership 投影
-      status: stub
-
-  servers:
-    - name: web-bff
-      path: servers/bff/web-bff
-      role: BFF 同步请求入口
-      status: reference
-    - name: gateway
-      path: servers/gateway
-      role: 网关入口
-      status: reference
-
-  workers:
-    - name: indexer
-      path: workers/indexer
-      role: 索引 worker 占位
-      status: stub
-    - name: outbox-relay
-      path: workers/outbox-relay
-      role: 至少一次投递、去重、checkpoint、retry 样例；当前已具结构参考价值但未完全收敛
-      status: reference
-    - name: projector
-      path: workers/projector
-      role: projection、rebuild、replay、lag SLO 样例骨架；当前仍需继续补齐
-      status: reference
-    - name: scheduler
-      path: workers/scheduler
-      role: 调度 worker 占位
-      status: stub
-    - name: sync-reconciler
-      path: workers/sync-reconciler
-      role: 同步协调 worker 占位
-      status: stub
-
-planned_or_stub_domains:
-  services:
-    - auth
-    - indexing
-    - user
-  note: >
-    这些域可以存在为 stub 或 planned，但默认学习路径仍应优先从 counter-service 开始。
-
-ownership:
-  generated_readonly:
-    - infra/kubernetes/rendered/**
-    - docs/generated/**
-    - platform/catalog/**
-
-  human_authored:
-    - agent/**
-    - packages/sdk/rust/**
-    - platform/schema/**
-    - platform/model/**
-    - packages/contracts/**
-    - services/**
-    - servers/**
-    - workers/**
-    - verification/**
-    - docs/architecture/**
-    - docs/operations/**
-    - docs/adr/**
+human_authored:
+  - AGENTS.md
+  - agent/**
+  - docs/architecture/**
+  - docs/operations/**
+  - docs/adr/**
+  - platform/schema/**
+  - platform/model/**
+  - platform/generators/**
+  - platform/validators/**
+  - packages/contracts/**
+  - services/**
+  - servers/**
+  - workers/**
+  - verification/**
+  - fixtures/**
+  - scripts/**
+  - justfiles/**
 
 write_boundaries:
-  - area: planner
+  planner:
     may_modify:
+      - AGENTS.md
       - agent/**
       - docs/**
+      - root config
     must_not_modify:
-      - infra/kubernetes/rendered/**
+      - generated_readonly
 
-  - area: platform-model
+  platform-ops-agent:
     may_modify:
       - platform/schema/**
       - platform/model/**
       - platform/generators/**
       - platform/validators/**
+      - infra/**
+      - ops/**
       - docs/operations/**
-      - docs/platform-model/**
     must_not_modify:
       - services/*/src/**
       - apps/**
-    notes: >
-      platform-ops-agent 负责平台级元数据与全局规则，不直接承载 service 细粒度语义实现。
+      - generated_readonly
 
-  - area: services
+  contract-agent:
+    may_modify:
+      - packages/contracts/**
+      - docs/contracts/**
+      - verification/contract/**
+    must_not_modify:
+      - services/*/src/domain/**
+      - servers/**/src/handlers/**
+      - generated_readonly
+
+  service-agent:
     may_modify:
       - services/**
-      - packages/contracts/**
       - fixtures/**
       - verification/**
     must_not_modify:
       - infra/**
       - platform/catalog/**
-      - platform/model/**
-    notes: >
-      service-agent 必须在 services/<name>/model.yaml 中维护该 service 的 distributed semantics。
+      - apps/**
+    note: Contract shape changes still start in packages/contracts/**.
 
-  - area: servers
+  server-agent:
     may_modify:
       - servers/**
-      - packages/contracts/**
       - verification/contract/**
     must_not_modify:
-      - services/*/domain/**
+      - services/*/src/domain/**
       - infra/**
-    notes: server 只能做协议适配与聚合。
+      - apps/**
 
-  - area: workers
+  worker-agent:
     may_modify:
       - workers/**
       - verification/resilience/**
@@ -283,299 +237,81 @@ write_boundaries:
     must_not_modify:
       - apps/**
       - infra/**
-    notes: worker 必须声明幂等、重试、checkpoint/replay、恢复顺序。
 
-  - area: infra
+  app-shell-agent:
     may_modify:
-      - infra/local/**
-      - infra/kubernetes/base/**
-      - infra/kubernetes/addons/**
-      - infra/gitops/**
-      - infra/security/**
-      - infra/images/**
-      - ops/**
+      - apps/**
+      - packages/ui/**
+      - verification/e2e/**
     must_not_modify:
-      - infra/kubernetes/rendered/**
-    notes: rendered 为生成目录，只能通过生成器刷新。
+      - services/**
+      - servers/**
+      - workers/**
 
-rules:
-  imports:
-    - name: apps-cannot-import-services
-      from: apps/**
-      disallow:
-        - services/**
-
-    - name: apps-cannot-import-workers
-      from: apps/**
-      disallow:
-        - workers/**
-
-    - name: services-cannot-import-other-services
-      from: services/**
-      disallow:
-        - services/**
-      except_same_module: true
-
-    - name: services-cannot-import-concrete-adapters
-      from: services/**
-      disallow:
-        - packages/data-adapters/**
-        - packages/cache-adapters/**
-        - packages/storage-adapters/**
-        - packages/authz-adapters/**
-        - packages/authn/adapters/**
-        - packages/observability/adapters/**
-        - infra/**
-        - ops/**
-      except:
-        # Integration tests need concrete adapters (dev-dependencies only).
-        - "services/counter-service:packages/data-adapters/turso"
-
-    - name: servers-can-import-services-and-packages
-      from: servers/**
-      allow:
-        - services/**
-        - packages/**
-
-    - name: workers-can-import-services-and-packages
-      from: workers/**
-      allow:
-        - services/**
-        - packages/**
-
-    - name: platform-cannot-import-runtime-business
-      from: platform/**
-      disallow:
-        - services/**
-        - servers/**
-        - workers/**
-        - apps/**
-
-state_rules:
-  owner_service:
-    description: 每个核心实体必须存在唯一 owner service
-    required: true
-
-  cross_service_writes:
-    description: 非 owner service 禁止直接写主状态
-    default: forbidden
-    escape_hatch: 仅允许通过 command 或 workflow 间接变更
-
-  consistency:
-    description: query、authz check、workflow dependent read 必须声明 consistency level
-    allowed_values:
-      - strong
-      - read-your-write
-      - monotonic-read
-      - bounded-staleness
-      - eventual
-
-  projection:
-    description: projection 必须可删可重建
-    required_fields:
-      - source
-      - checkpoint_key
-      - rebuildable
-      - replayable
-
-  idempotency:
-    description: 跨进程副作用必须声明 idempotency key 与 dedupe 语义
-    required_for:
-      - commands_with_side_effects
-      - workers
-      - workflows
-      - relays
-
-messaging_rules:
-  delivery_assumption: 默认至少一次；消费逻辑必须默认接受重复、重试、延迟与重放
-  forbidden_assumptions:
-    - 默认 exactly-once
-    - 默认全局顺序
-    - 默认永不重复
-    - 默认消息必达且准时
-  event_required_fields:
-    - producer
-    - ordering_scope
-    - dedupe_rule
-    - replayable
-    - schema_version
-    - compatibility_policy
-
-workflow_rules:
-  use_workflow_when:
-    - 跨 service 多步状态变更
-    - 有重试与补偿需求
-    - 需要 durable execution
-    - 需要人工介入恢复点
-  required_fields:
-    - trigger
-    - idempotency_key
-    - timeout
-    - checkpoint_policy
-    - compensation
-    - recovery
-  forbidden_patterns:
-    - HTTP handler 串多个 service 并 try/catch 回滚
-    - worker 中手写隐式长事务但没有模型
-    - 运维脚本充当长期恢复逻辑
-
-deployable_rules:
-  statefulness:
-    allowed_values:
-      - stateless
-      - checkpointed
-      - stateful
-  stable_identity_required_when:
-    - 拥有持久本地状态
-    - 需要唯一实例持有语义
-    - checkpoint 与实例身份绑定
-    - 运行分区或 shard owner
-  required_fields:
-    - kind
-    - hosts_services
-    - runtime_profile
-    - statefulness
-    - required_identity
-    - required_storage
-    - resource_bindings
-    - failure_domain
-
-decision_tree:
-  add_new_logic:
-    ask_in_order:
-      - 这是新业务能力，还是现有 service 的扩展？
-      - 核心实体归哪个 owner service？
-      - 这是 command、event、query，还是 workflow？
-      - 是否跨 service 多步状态变更？若是，必须 workflow 化。
-      - 是否需要 projection？若是，必须声明可重建。
-      - 是否涉及外部副作用？若是，必须声明 idempotency key。
-      - 是否需要稳定身份、持久存储、checkpoint？
-      - 是否引入新的 consistency requirement？
-
-  add_new_service:
-    must_create: 参见 `required_files.service`
-    must_update:
-      - platform/model/services/<name>.yaml
-      - platform/model/state/ownership-map.yaml
-      - agent/codemap.yml
-
-  add_new_worker:
-    must_create: 参见 `required_files.worker`
-    must_update:
-      - platform/model/deployables/<name>.yaml
-      - platform/model/workflows/ 或 services/*/model.yaml
-      - verification/replay/ 或 verification/resilience/
-
-change_playbooks:
-  change_contract:
-    steps:
-      - 先修改 packages/contracts
-      - 同步修改 services/<name>/model.yaml 中的 commands/events/queries
-      - 运行 contract compatibility validator
-      - 再修改 servers/workers/services 实现
-      - 最后生成 sdk
-
-  change_state_owner:
-    steps:
-      - 修改 services/<name>/model.yaml 的 owns_entities
-      - 更新 platform/model/state/ownership-map.yaml
-      - 检查 workflow 与 projection 影响
-      - 更新 replay/compatibility tests
-    risk: high
-
-  change_topology:
-    steps:
-      - 修改 platform/model/topologies
-      - 检查 deployables 与 failures
-      - 验证 topology 不改变状态语义
-      - 更新 verification/topology
-      - 再生成 infra rendered
-    risk: medium
+dependency_direction:
+  - from: apps/**
+    must_not_import:
+      - services/**
+      - workers/**
+    note: Apps consume SDKs, contracts, or HTTP APIs, not service libraries.
+  - from: services/**
+    must_not_import:
+      - services/**
+      - infra/**
+      - ops/**
+      - packages/data-adapters/**
+      - packages/cache-adapters/**
+      - packages/storage-adapters/**
+    note: Services are pure libraries and use ports/traits at boundaries.
+  - from: servers/**
+    may_import:
+      - services/**
+      - packages/**
+    note: Servers compose services and adapt protocols; they do not own domain logic.
+  - from: workers/**
+    may_import:
+      - services/**
+      - packages/**
+    note: Workers compose services for async execution and must make recovery behavior explicit in code and tests.
+  - from: platform/**
+    must_not_import:
+      - services/**
+      - servers/**
+      - workers/**
+      - apps/**
+    note: Platform tooling validates and generates metadata; it does not depend on runtime business code.
 
 anti_patterns:
-  - id: direct-db-from-server
-    description: server 直接操作数据库
-    severity: error
-  - id: cross-service-import
-    description: service 直接依赖其他 service
-    severity: error
-  - id: cross-service-direct-write
-    description: 非 owner service 直接写主状态
-    severity: error
-  - id: handler-long-transaction
-    description: 在 handler 里串多个 service 形成长事务
-    severity: error
-  - id: projection-as-source-of-truth
-    description: 把 projection 当真相源
-    severity: error
-  - id: hidden-idempotency
-    description: 幂等逻辑只存在代码中，没有模型声明
-    severity: warn
-  - id: topology-changing-semantics
-    description: 通过 topology 改变状态语义
+  - id: yaml-as-proof
+    description: Treating YAML declarations as proof of semantic correctness.
     severity: error
   - id: generated-manual-edit
-    description: 手改 generated 目录
+    description: Editing generated directories by hand instead of changing sources and regenerating.
     severity: error
-  - id: event-bus-as-domain-service
-    description: 把纯基础设施能力伪装成业务 service
+  - id: subagent-bound-gates
+    description: Requiring gates only because a subagent touched a change, instead of using changed paths, risk, and evidence level.
+    severity: error
+  - id: all-gates-for-all-changes
+    description: Making ordinary development run release, production, frontend, desktop, or platform-full gates by default.
+    severity: error
+  - id: cross-service-import
+    description: A service directly depends on another service instead of contracts, ports, events, commands, or workflows.
+    severity: error
+  - id: server-owns-domain-logic
+    description: Handler or server code owns business state transitions that belong in services.
+    severity: error
+  - id: hidden-distributed-semantics
+    description: Idempotency, retry, checkpoint, replay, consistency, or ownership behavior exists only implicitly and lacks tests or gate evidence.
     severity: warn
+  - id: topology-changing-semantics
+    description: Topology or deployable metadata changes business state semantics without service-level implementation and verification.
+    severity: error
 
-required_files:
-  service:
-    - model.yaml
-    - Cargo.toml
-    - src/lib.rs
-    - src/domain/
-    - src/application/
-    - src/policies/
-    - src/ports/
-    - src/events/
-    - src/contracts/
-    - tests/
-    - migrations/
-    - README.md
-
-  server:
-    - Cargo.toml
-    - openapi.yaml
-    - src/main.rs
-    - src/handlers/
-    - src/middleware/
-    - src/routes/
-    - src/composition/
-    - README.md
-
-  worker:
-    - Cargo.toml
-    - src/main.rs
-    - src/config.rs
-    - src/job_or_consumer/
-    - src/checkpoint/
-    - src/dedupe/
-    - src/retry/
-    - src/metrics/
-    - README.md
-
-validation:
-  commands:
-    - just doctor
-    - just lint
-    - just test
-    - just validate-platform
-    - just validate-state
-    - just validate-workflows
-    - just validate-contracts
-    - just validate-topology
-    - just verify-generated
-    - just verify-replay
-    - just verify-compat
-    - just verify-resilience
-
-entry_rules:
-  - 变更顺序：先确认是否需要改 platform/schema
-  - 变更顺序：再改 platform/model 或 services/<name>/model.yaml
-  - 变更顺序：再改 packages/contracts
-  - 变更顺序：再改 services/**
-  - 变更顺序：再改 servers/** 和 workers/**
-  - 变更顺序：最后改 infra/**、生成物和补充文档
+modification_order:
+  - If a new metadata shape is needed, update schema and validators before model files.
+  - If external protocol shape changes, update packages/contracts/** before implementation.
+  - If service semantics change, update services/<name>/model.yaml as a summary and add executable verification for the behavior.
+  - Change service libraries before server or worker composition that consumes them.
+  - Change server and worker entrypoints before app shells that depend on their APIs.
+  - Change platform model before infra rendering, and never edit generated rendered output directly.
+  - Select gates from agent/manifests/gate-matrix.yml based on changed paths, risk, and evidence level.

--- a/agent/manifests/gate-matrix.yml
+++ b/agent/manifests/gate-matrix.yml
@@ -1,154 +1,309 @@
 # Gate Matrix
-# Maps subagents to their required gates
-# Used by planner to determine which gates to run after subagent completes
+# Select gates from changed paths, risk category, and evidence level.
+# Subagent identity routes work; it does not make a gate required.
 
-version: 1
-updated: "2026-04-14"
+version: 2
+updated: "2026-04-27"
 
-# Gate definitions
+strengths:
+  advisory:
+    blocking: false
+    purpose: Early signal, optional lanes, non-default shells, or exploratory checks.
+  guardrail:
+    blocking: true
+    purpose: Normal PR protection for boundaries, drift, default backend-core, contracts, and path-scoped validation.
+  invariant:
+    blocking: true
+    purpose: P0 correctness and release readiness only; requires executable evidence.
+
+evidence_levels:
+  declared:
+    source: Metadata or prose only.
+    can_be_claimed_from_yaml_only: true
+  checked:
+    source: Schema validation, static validation, typecheck, drift check, or boundary check.
+    can_be_claimed_from_yaml_only: false
+  tested:
+    source: Unit, integration, contract, replay, resilience, or end-to-end tests.
+    can_be_claimed_from_yaml_only: false
+  proven:
+    source: Executed gate or test evidence appropriate for the claimed invariant.
+    can_be_claimed_from_yaml_only: false
+
 gates:
-  typegen:
-    command: ["moon", "run", "repo:typegen"]
-    label: "Type generation"
-    scope: contract
+  verify_backend_primary:
+    command: ["just", "verify-backend-primary"]
+    label: Default backend-core static guardrail
+    strength: guardrail
+    scope: backend-core
 
-  drift_check:
-    command: ["git", "diff", "--exit-code", "packages/contracts/generated/"]
-    label: "Contract drift check"
-    scope: contract
+  test_backend_primary:
+    command: ["just", "test-backend-primary"]
+    label: Default backend-core tests
+    strength: guardrail
+    scope: backend-core
 
-  typecheck:
-    command: ["just", "typecheck"]
-    label: "Type check"
-    scope: global
+  verify_repo:
+    command: ["just", "verify"]
+    label: Repo-wide backend-core verify
+    strength: guardrail
+    scope: repo
+    note: Use when broader confidence is needed; not a default requirement for every change.
 
   boundary_check:
     command: ["just", "boundary-check"]
-    label: "Boundary check"
-    scope: global
+    label: Boundary check
+    strength: guardrail
+    scope: repo
 
-  cargo_check:
-    command: ["cargo", "check", "-p", "<package>"]
-    label: "Cargo check"
-    scope: rust
-    variable: "package"
+  typecheck:
+    command: ["just", "typecheck"]
+    label: Type check
+    strength: guardrail
+    scope: repo
 
-  cargo_test:
-    command: ["cargo", "test", "-p", "<package>"]
-    label: "Cargo test"
-    scope: rust
-    variable: "package"
-
-  contract_check:
-    command: ["just", "contracts-check"]
-    label: "Contract checks"
+  contracts_check:
+    command: ["just", "contracts-check", "strict"]
+    label: Contract validation
+    strength: guardrail
     scope: contract
 
-  resilience_check:
-    command: ["bun", "run", "scripts/validate-resilience.ts", "--mode", "warn"]
-    label: "Resilience checks"
-    scope: worker
+  typegen:
+    command: ["just", "typegen"]
+    label: Contract type generation
+    strength: guardrail
+    scope: contract
 
-  validate_state:
-    command: ["just", "validate-state", "strict"]
-    label: "State validation"
-    scope: platform
+  drift_check:
+    command: ["just", "drift-check"]
+    label: Contract generated drift check
+    strength: guardrail
+    scope: contract
 
-  validate_workflows:
-    command: ["just", "validate-workflows", "strict"]
-    label: "Workflow validation"
-    scope: platform
-
-  verify_replay:
-    command: ["just", "verify-replay", "strict"]
-    label: "Replay verification"
-    scope: worker
-
-  verify_counter_delivery:
-    command: ["just", "verify-counter-delivery", "strict"]
-    label: "Counter delivery verification"
-    scope: platform
+  sdk_drift_check:
+    command: ["just", "sdk-drift-check"]
+    label: SDK drift check
+    strength: guardrail
+    scope: contract
 
   validate_platform:
     command: ["just", "validate-platform"]
-    label: "Platform validation"
+    label: Platform model validation
+    strength: guardrail
     scope: platform
+
+  validate_state:
+    command: ["just", "validate-state", "strict"]
+    label: State metadata validation
+    strength: guardrail
+    scope: platform
+    note: Checks declarations; does not prove runtime state correctness by itself.
+
+  validate_workflows:
+    command: ["just", "validate-workflows", "strict"]
+    label: Workflow metadata validation
+    strength: guardrail
+    scope: platform
+    note: Checks declarations; does not prove workflow runtime correctness by itself.
 
   validate_topology:
     command: ["just", "validate-topology"]
-    label: "Topology validation"
+    label: Topology validation
+    strength: guardrail
     scope: platform
 
   verify_generated:
     command: ["just", "verify-generated"]
-    label: "Generated drift checks"
+    label: Generated artifact drift check
+    strength: guardrail
     scope: platform
 
-  validate_deps:
-    command: ["just", "validate-deps"]
-    label: "Local/infra validation"
-    scope: platform
+  verify_replay:
+    command: ["just", "verify-replay", "strict"]
+    label: Replay verification
+    strength: invariant
+    scope: worker
 
-  verify:
-    command: ["just", "verify"]
-    label: "Total verify"
-    scope: global
-    note: "Always run as final gate"
+  verify_counter_delivery:
+    command: ["just", "verify-counter-delivery", "strict"]
+    label: Counter delivery admission verification
+    strength: invariant
+    scope: delivery
 
-# Subagent → gate mapping
-subagent_gates:
-  contract-agent:
+  validate_resilience:
+    command: ["bun", "run", "scripts/validate-resilience.ts", "--mode", "warn"]
+    label: Resilience checks
+    strength: advisory
+    scope: worker
+
+  gate_release:
+    command: ["just", "gate-release"]
+    label: Release gate
+    strength: invariant
+    scope: release
+
+path_rules:
+  - match:
+      - AGENTS.md
+      - agent/**
+      - docs/architecture/**
+    recommended:
+      - boundary_check
+    required: []
+    note: Coordination-only changes should not trigger heavy platform or release gates by default.
+
+  - match:
+      - justfile
+      - justfiles/**
+      - moon.yml
+      - package.json
+      - scripts/**
+    recommended:
+      - boundary_check
+      - typecheck
     required:
+      - verify_backend_primary
+    note: Shared tooling can affect the backend-core lane; prefer scoped checks before repo-wide verify.
+
+  - match:
+      - packages/contracts/**
+      - docs/contracts/**
+    recommended:
       - typegen
       - drift_check
+      - sdk_drift_check
       - typecheck
       - boundary_check
-    conditional: []
+    required:
+      - contracts_check
 
-  app-shell-agent:
+  - match:
+      - services/**
+    recommended:
+      - verify_backend_primary
+      - test_backend_primary
+      - boundary_check
     required: []
-    conditional: []
+    note: Add contract, replay, or invariant gates only when the actual service change affects those risks.
 
-  server-agent:
-    required:
-      - cargo_check
-      - typecheck
+  - match:
+      - servers/**
+    recommended:
+      - verify_backend_primary
       - boundary_check
-    conditional:
-      - gate: contract_check
-        when: "packages/contracts/ changed"
+    required: []
+    note: Add contracts_check when request/response/error shapes change.
 
-  service-agent:
-    required:
-      - cargo_check
-      - cargo_test
-      - validate_state
-      - typecheck
+  - match:
+      - workers/**
+    recommended:
+      - verify_backend_primary
       - boundary_check
-    conditional: []
+      - validate_resilience
+    required: []
+    note: Escalate to verify_replay when checkpoint, replay, projection rebuild, outbox, or idempotency behavior changes.
 
-  worker-agent:
-    required:
-      - cargo_check
-      - cargo_test
-      - verify_replay
-      - resilience_check
-      - boundary_check
-    conditional: []
-
-  platform-ops-agent:
-    required:
+  - match:
+      - platform/schema/**
+      - platform/model/**
+      - platform/validators/**
+      - platform/generators/**
+    recommended:
       - validate_platform
       - validate_state
       - validate_workflows
-      - validate_topology
-      - verify_counter_delivery
-      - verify_generated
-      - validate_deps
       - boundary_check
-    conditional: []
+    required: []
+    note: These gates validate declarations and generators; invariant claims need tests or stricter delivery evidence.
 
-# Global gates (always run after all subagents complete)
-global_gates:
-  - verify           # just verify
-  - boundary_check   # just boundary-check
+  - match:
+      - infra/**
+      - ops/**
+    recommended:
+      - validate_platform
+      - validate_topology
+      - boundary_check
+    required: []
+    note: Escalate for secrets, topology, GitOps, or production delivery changes.
+
+  - match:
+      - verification/**
+      - fixtures/**
+    recommended:
+      - verify_backend_primary
+      - boundary_check
+    required: []
+    note: Run the specific verification lane being changed.
+
+  - match:
+      - apps/**
+      - packages/ui/**
+    recommended: []
+    required: []
+    note: App shells use their own local command surface; root backend-core gates should not depend on them by default.
+
+risk_rules:
+  contract_compatibility:
+    when: External DTO, event, RPC, OpenAPI, SDK, or error-code shape changes.
+    add_recommended:
+      - contracts_check
+      - typegen
+      - drift_check
+      - sdk_drift_check
+    minimum_evidence: checked
+
+  backend_core_behavior:
+    when: Default counter/tenant/web-bff backend behavior changes without distributed semantics risk.
+    add_recommended:
+      - verify_backend_primary
+      - test_backend_primary
+      - boundary_check
+    minimum_evidence: tested
+
+  distributed_semantics:
+    when: Idempotency, retry, checkpoint, replay, ordering, projection rebuild, outbox delivery, workflow, or ownership semantics change.
+    add_required:
+      - verify_replay
+    add_recommended:
+      - validate_state
+      - validate_workflows
+      - test_backend_primary
+    minimum_evidence: proven
+
+  topology_or_delivery:
+    when: Topology, deployable identity, secrets, SOPS, GitOps, delivery path, or production resource binding changes.
+    add_required:
+      - validate_topology
+    add_recommended:
+      - validate_platform
+      - verify_counter_delivery
+    minimum_evidence: checked
+
+  release_readiness:
+    when: Preparing a release, changing release automation, or claiming release readiness.
+    add_required:
+      - gate_release
+    add_recommended:
+      - verify_repo
+      - verify_generated
+    minimum_evidence: proven
+
+  p0_correctness:
+    when: A failure could corrupt data, bypass authorization, leak secrets, break recovery, or invalidate delivery correctness.
+    add_required:
+      - gate_release
+    add_recommended:
+      - verify_repo
+      - verify_replay
+      - verify_counter_delivery
+    minimum_evidence: proven
+
+selection_rules:
+  - Start from changed paths, then add risk-specific gates.
+  - Advisory gates do not block unless a maintainer explicitly promotes them for the change.
+  - Guardrail gates may block normal PRs.
+  - Invariant gates are reserved for P0 correctness and release readiness.
+  - Do not claim a gate passed unless it was executed in this change context.
+  - Do not claim semantic correctness from YAML-only changes.
+  - Prefer `just verify-backend-primary` for ordinary backend-core work.
+  - Use `just verify` for broader repo-wide confidence, not as an automatic final gate for every change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,9 +17,10 @@ For general readers and template adopters:
 For maintainers and agent-assisted development:
 
 1. `AGENTS.md`
-2. `agent/codemap.yml`
-3. `docs/adr/**`
-4. `docs/governance/docs-lifecycle.md`
+2. `docs/architecture/harness-philosophy.md`
+3. `agent/codemap.yml`
+4. `docs/adr/**`
+5. `docs/governance/docs-lifecycle.md`
 
 ## What Belongs Here
 

--- a/docs/architecture/harness-philosophy.md
+++ b/docs/architecture/harness-philosophy.md
@@ -1,0 +1,81 @@
+# Harness Philosophy
+
+This repository uses the agent harness as a coordination layer. It is not a formal architecture constitution, a proof system, or a replacement for executable verification.
+
+## Boundary
+
+The harness may:
+
+1. map changed paths to likely owners
+2. point agents at source-of-truth files
+3. recommend gates based on path, risk, and evidence needs
+4. record durable coordination rules that should remain stable across tasks
+
+The harness must not:
+
+1. claim semantic correctness from YAML metadata alone
+2. turn every local change into a full release gate
+3. make subagent identity the reason a gate is required
+4. duplicate volatile implementation details that are better read from code, tests, scripts, or schemas
+
+## Truth Hierarchy
+
+When sources disagree, use this order:
+
+1. code, schemas, validators, executable tests, gates, and command output
+2. generated artifacts only when they are produced by the current source and verified for drift
+3. platform and service metadata such as `platform/model/**` and `services/*/model.yaml`
+4. coordination manifests such as `agent/codemap.yml`, `routing-rules.yml`, and `gate-matrix.yml`
+5. prose documentation and historical notes
+
+Metadata can describe intent, ownership, topology, or semantic summaries. It cannot prove the implementation satisfies those semantics.
+
+## Metadata Is Not Proof
+
+`agent/codemap.yml` is a navigation map. It should stay small and point to boundaries, sources of truth, generated-readonly locations, anti-patterns, and modification order.
+
+`services/<name>/model.yaml` is a service semantic summary. It should help reviewers find declared ownership, commands, events, queries, consistency expectations, idempotency notes, and replay assumptions. It is not a formal proof.
+
+`platform/model/**` describes platform shape and global deployable metadata. It does not prove runtime safety, state correctness, or release readiness by itself.
+
+Do not upgrade a claim from `declared` to `checked`, `tested`, or `proven` by editing metadata alone.
+
+## Evidence Levels
+
+Use these terms consistently:
+
+1. `declared`: written in metadata or docs; useful for navigation, not evidence of behavior
+2. `checked`: validated by a schema, static validator, drift check, typecheck, or boundary check
+3. `tested`: exercised by unit, integration, contract, replay, or end-to-end tests
+4. `proven`: supported by an explicit gate or test run that is appropriate for the claimed invariant and cited in the change record
+
+An agent may only raise evidence level by referencing executable evidence: test names, gate names, scripts, or command output that actually ran.
+
+## Gate Strength
+
+Gate strength is separate from subagent identity.
+
+1. `advisory`: gives signal but does not block. Use for early warnings, optional lanes, exploratory checks, or non-default shells.
+2. `guardrail`: may block a PR. Use for boundary checks, contract drift, default backend-core static checks, and path-scoped validation that protects normal development.
+3. `invariant`: reserved for P0 correctness and release readiness. Use only when the change affects data correctness, distributed semantics, ownership, authorization, secrets, topology, replay, or production delivery paths.
+
+P0 invariants must be demonstrated by executable tests, gates, or command-output evidence. YAML declarations can point to the invariant, but they do not prove it.
+
+## Default Backend Core
+
+The default backend-core lane should remain light enough for ordinary development. Prefer `just verify-backend-primary` and path-scoped guardrails before requiring repo-wide or release gates.
+
+`just verify` is the default repo-wide backend-core gate when broader confidence is needed, but it should not imply that every change must run platform, frontend, desktop, production, or release gates.
+
+Release and full gates may be heavier. They belong to release preparation, P0 invariant changes, platform topology changes, distributed semantics changes, or explicit reviewer request.
+
+## Applying Gates
+
+Choose gates from changed paths, risk category, and evidence level:
+
+1. path decides what changed
+2. risk decides how strong the gate must be
+3. evidence level decides what can be claimed afterward
+4. subagent identity only helps route work; it does not make a gate required
+
+If a gate was not run, say so. If a gate is advisory, do not describe it as blocking. If a gate is a release or invariant gate, explain the P0 or release risk that justifies it.

--- a/scripts/run-scoped-gates.ts
+++ b/scripts/run-scoped-gates.ts
@@ -1,197 +1,65 @@
 /**
- * Run Scoped Gates — Execute gates specific to a subagent's domain
- * instead of running the full global gate.
+ * Gate selection helper.
+ *
+ * Gates are selected from changed paths, risk category, and evidence level.
+ * Subagent identity routes work but no longer makes a gate required.
  *
  * Usage:
- *   bun run scripts/run-scoped-gates.ts contract-agent
- *   bun run scripts/run-scoped-gates.ts app-shell-agent
- *   bun run scripts/run-scoped-gates.ts server-agent
+ *   bun run scripts/run-scoped-gates.ts --list
  *   bun run scripts/run-scoped-gates.ts service-agent
- *   bun run scripts/run-scoped-gates.ts worker-agent
- *   bun run scripts/run-scoped-gates.ts platform-ops-agent
- *   bun run scripts/run-scoped-gates.ts --list    # show all available gates
  */
 
-import { run } from './lib/spawn.ts';
 import process from 'node:process';
 
-interface GateStep {
-  label: string;
-  cmd: string;
-  args: string[];
-  skip?: boolean;
-  todo?: string;
+const gateMatrix = 'agent/manifests/gate-matrix.yml';
+
+const legacyAgents = [
+  'contract-agent',
+  'app-shell-agent',
+  'server-agent',
+  'service-agent',
+  'worker-agent',
+  'platform-ops-agent',
+];
+
+function printGuidance(): void {
+  console.log('\n=== Gate Selection ===\n');
+  console.log('Gate selection is path/risk/evidence based, not subagent based.');
+  console.log(`Use ${gateMatrix} to select advisory, guardrail, or invariant gates.`);
+  console.log('Default backend-core guardrail: just verify-backend-primary');
+  console.log('Broader repo-wide guardrail when needed: just verify');
+  console.log('Release/P0 invariant gate only when justified: just gate-release');
+  console.log('\nLegacy agent names accepted by this helper:');
+  for (const agent of legacyAgents) {
+    console.log(`  - ${agent}`);
+  }
 }
 
-interface SubagentGates {
-  required: GateStep[];
-  conditional: (GateStep & { when: string })[];
-}
-
-// Gate definitions — derived from agent/manifests/gate-matrix.yml
-// When updating gates, also update the manifest
-const SUBAGENT_GATES: Record<string, SubagentGates> = {
-  'contract-agent': {
-    required: [
-      { label: 'Type generation', cmd: 'moon', args: ['run', 'repo:typegen'] },
-      { label: 'Typecheck', cmd: 'just', args: ['typecheck'] },
-      { label: 'Boundary check', cmd: 'just', args: ['boundary-check'] },
-    ],
-    conditional: [],
-  },
-  'app-shell-agent': {
-    required: [],
-    conditional: [],
-  },
-  'server-agent': {
-    required: [
-      { label: 'Typecheck', cmd: 'just', args: ['typecheck'] },
-      { label: 'Boundary check', cmd: 'just', args: ['boundary-check'] },
-    ],
-    conditional: [
-      { label: 'Contract checks', cmd: 'just', args: ['contracts-check'], when: 'packages/contracts/ changed' },
-    ],
-  },
-  'service-agent': {
-    required: [
-      { label: 'State validation', cmd: 'just', args: ['validate-state', 'strict'] },
-      { label: 'Typecheck', cmd: 'just', args: ['typecheck'] },
-      { label: 'Boundary check', cmd: 'just', args: ['boundary-check'] },
-    ],
-    conditional: [],
-  },
-  'worker-agent': {
-    required: [
-      { label: 'Replay verification', cmd: 'just', args: ['verify-replay', 'strict'] },
-      { label: 'Typecheck', cmd: 'just', args: ['typecheck'] },
-      { label: 'Boundary check', cmd: 'just', args: ['boundary-check'] },
-      { label: 'Resilience checks', cmd: 'bun', args: ['run', 'scripts/validate-resilience.ts', '--mode', 'warn'] },
-    ],
-    conditional: [],
-  },
-  'platform-ops-agent': {
-    required: [
-      { label: 'Platform validation', cmd: 'just', args: ['validate-platform'] },
-      { label: 'State validation', cmd: 'just', args: ['validate-state', 'strict'] },
-      { label: 'Workflow validation', cmd: 'just', args: ['validate-workflows', 'strict'] },
-      { label: 'Topology validation', cmd: 'just', args: ['validate-topology'] },
-      { label: 'Counter delivery verification', cmd: 'just', args: ['verify-counter-delivery', 'strict'] },
-      { label: 'Generated drift checks', cmd: 'just', args: ['verify-generated'] },
-      { label: 'Boundary check', cmd: 'just', args: ['boundary-check'] },
-    ],
-    conditional: [],
-  },
-};
-
-async function runGate(gate: GateStep, packageName?: string): Promise<{ success: boolean; skipped: boolean }> {
-  if (gate.skip) {
-    console.warn(`  ⚠ SKIP: ${gate.label} — ${gate.todo || 'not implemented'}`);
-    return { success: true, skipped: true };
-  }
-
-  const cmd = gate.args.map((a) =>
-    a === '<package>' ? (packageName || 'unknown') : a
-  );
-
-  console.log(`\n→ ${gate.label}: ${gate.cmd} ${cmd.join(' ')}`);
-
-  const result = await run(gate.cmd, cmd, { stdio: 'pipe' });
-
-  if (result.output) {
-    const lines = result.output.split('\n').slice(-5);
-    for (const line of lines) {
-      console.log(`  ${line}`);
-    }
-  }
-
-  if (result.success) {
-    console.log(`  ✓ ${gate.label}`);
-    return { success: true, skipped: false };
-  }
-
-  if (result.error) {
-    console.error(`  ✗ ${gate.label}: ${result.error}`);
-  }
-
-  return { success: false, skipped: false };
-}
-
-async function main(): Promise<number> {
+function main(): number {
   const args = process.argv.slice(2);
 
   if (args.includes('--list') || args.includes('-l')) {
-    console.log('\n=== Available Subagents and Gates ===\n');
-    for (const [agent, gates] of Object.entries(SUBAGENT_GATES)) {
-      console.log(`${agent}:`);
-      const required = gates.required.map((g) => g.label).join(', ') || '(none at root)';
-      console.log(`  Required:   ${required}`);
-      if (gates.conditional.length > 0) {
-        console.log(`  Conditional: ${gates.conditional.map((c) => `${c.label} (when: ${c.when})`).join(', ')}`);
-      }
-      console.log();
-    }
-    console.log('Full definitions: agent/manifests/gate-matrix.yml');
+    printGuidance();
     return 0;
   }
 
   const agent = args[0];
   if (!agent) {
-    console.error('Usage: bun run scripts/run-scoped-gates.ts <subagent-name>');
-    console.error('Run with --list to see available subagents');
+    console.error('Usage: bun run scripts/run-scoped-gates.ts [--list|<subagent-name>]');
     return 1;
   }
 
-  const agentGates = SUBAGENT_GATES[agent];
-
-  if (!agentGates) {
-    console.error(`Unknown subagent: ${agent}`);
-    console.error('Available subagents:');
-    for (const name of Object.keys(SUBAGENT_GATES)) {
-      console.error(`  ${name}`);
-    }
+  if (!legacyAgents.includes(agent)) {
+    console.error(`Unknown legacy subagent: ${agent}`);
+    console.error('Run with --list for guidance.');
     return 1;
   }
 
-  console.log(`\n=== Running scoped gates for ${agent} ===`);
-
-  if (agent === 'app-shell-agent') {
-    console.log('No root-scoped gates for app-shell-agent. Validate retained app shells from their own local command surface.');
-    console.log('Full gate definitions: agent/manifests/gate-matrix.yml');
-    return 0;
-  }
-
-  const failures: string[] = [];
-
-  // Run required gates
-  for (const gate of agentGates.required) {
-    const { success, skipped } = await runGate(gate);
-    if (!success && !skipped) {
-      failures.push(gate.label);
-    }
-  }
-
-  // Run conditional gates (simplified — runs all conditionals for now)
-  for (const gate of agentGates.conditional) {
-    console.log(`  (conditional: ${gate.when})`);
-    const { success, skipped } = await runGate(gate);
-    if (!success && !skipped) {
-      failures.push(gate.label);
-    }
-  }
-
-  if (failures.length > 0) {
-    console.error(`\n✗ ${agent} gates failed: ${failures.join(', ')}`);
-    return 1;
-  }
-
-  console.log(`\n✓ ${agent} scoped gates passed`);
-  console.log('Full gate definitions: agent/manifests/gate-matrix.yml');
+  console.log(`\n=== Gate Selection for ${agent} ===\n`);
+  console.log('No gate is required solely because this subagent handled the change.');
+  console.log(`Select gates from changed paths, risk, and evidence level in ${gateMatrix}.`);
+  console.log('This compatibility helper does not run heavy gates automatically.');
   return 0;
 }
 
-main()
-  .then((code) => process.exit(code))
-  .catch((err) => {
-    console.error('Fatal error:', err);
-    process.exit(1);
-  });
+process.exit(main());

--- a/scripts/verify-handoff.ts
+++ b/scripts/verify-handoff.ts
@@ -4,8 +4,8 @@
  *
  * This script:
  * 1. Checks that modified files are within the subagent's writable boundaries
- * 2. Runs the subagent's scoped gates
- * 3. Reports readiness for total verify
+ * 2. Prints gate-selection guidance
+ * 3. Reports readiness for path/risk/evidence-based verification
  *
  * Usage:
  *   bun run scripts/verify-handoff.ts contract-agent
@@ -119,7 +119,7 @@ async function main(): Promise<number> {
 
   if (paths.length === 0) {
     console.log('No modified files to verify.');
-    console.log('Run scoped gates anyway...');
+    console.log('Print gate-selection guidance anyway...');
   }
 
   console.log(`Modified files: ${paths.length}`);
@@ -148,22 +148,22 @@ async function main(): Promise<number> {
     console.log('Validate retained app shells from their own local command surface if those directories remain in the repo.');
     console.log('\n=== Handoff Verified ===');
     console.log(`${agent} changes are ready for convergence.`);
-    console.log('Next step: run total verify (just verify)');
+    console.log('Next step: select gates by changed paths, risk, and evidence level.');
     return 0;
   }
 
-  // Run scoped gates
-  console.log('\n--- Scoped Gates ---');
+  // Gate selection guidance. Gates are no longer required solely by subagent identity.
+  console.log('\n--- Gate Selection Guidance ---');
   const result = await run('bun', ['run', 'scripts/run-scoped-gates.ts', agent]);
 
   if (!result.success) {
-    console.error('\n✗ Scoped gates failed — handoff not ready');
+    console.error('\n✗ Gate selection guidance failed — handoff not ready');
     return 1;
   }
 
   console.log('\n=== Handoff Verified ===');
   console.log(`${agent} changes are ready for convergence.`);
-  console.log('Next step: run total verify (just verify)');
+  console.log('Next step: run gates selected by changed paths, risk, and evidence level.');
 
   return 0;
 }

--- a/tools/repo-release/CHANGELOG.md
+++ b/tools/repo-release/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this repository-level release anchor will be documented in this file.
+
+## Unreleased
+
+## v0.3.0 - 2026-04-27
+
+### Added
+
+- Added a dedicated harness philosophy document covering truth hierarchy, evidence levels, metadata limits, and gate strength.
+- Added explicit backend-core audit and validation guidance for template adopters.
+
+### Changed
+
+- Bumped the repository release anchor to `0.3.0` for the next template release.
+- Decoupled optional app-shell surfaces from the root backend-core contract.
+- Reworked agent control-plane guidance so codemap remains a navigation map and gate selection is based on changed paths, risk, and evidence level.
+- Clarified that YAML metadata can declare intent but cannot prove distributed semantics or P0 correctness.
+
+### Fixed
+
+- Fixed release-plz workflow scoping, baseline comparison, and worktree cleanliness for repository-level releases.

--- a/tools/repo-release/Cargo.toml
+++ b/tools/repo-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-harness"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Decouple optional app-shell surfaces from the root backend-core contract and keep default backend validation independent from SvelteKit/Tauri/UI shells.
- Fix repository-level release automation so release-plz uses the template release anchor, active baseline tag strategy, and a clean worktree.
- Converge the agent control plane by making `codemap.yml` a navigation map and selecting gates by changed paths, risk, and evidence level instead of subagent identity.
- Prepare the repository release anchor and changelogs for `v0.3.0`.

## Release Notes
- Adds `docs/architecture/harness-philosophy.md` to document harness boundaries, truth hierarchy, evidence levels, metadata limits, and gate strength.
- Clarifies that YAML metadata can declare intent but cannot prove semantic correctness; P0/release claims require executable evidence.
- Documents `advisory`, `guardrail`, and `invariant` gate tiers, with invariant gates reserved for P0 correctness and release readiness.
- Updates root and release-anchor changelogs with open-source-style sections: Added, Changed, Fixed, Documentation, and Migration Notes.

## Versioning
- Bumps `tools/repo-release` from `0.2.0` to `0.3.0`.
- Updates `Cargo.lock` for the repository release anchor.
- Keeps internal workspace crate versions unchanged; repository tags remain the public template version contract.

## Verification
- `bun run scripts/run-scoped-gates.ts --list`
- `bun run scripts/run-scoped-gates.ts service-agent`
- `bun run scripts/verify-handoff.ts service-agent`
- `bun run scripts/audit-backend-core.ts dry-run`
- `bun run scripts/audit-backend-core.ts strict`
- `just boundary-check`
- `ruby -e 'require \"yaml\"; ARGV.each { |f| YAML.load_file(f); puts \"OK #{f}\" }' agent/codemap.yml agent/manifests/gate-matrix.yml agent/manifests/routing-rules.yml`
- `just verify-backend-primary`
- `just typecheck`
- `cargo metadata --no-deps --format-version 1`
- `cargo check -p axum-harness`
- `just semver-check v0.2.0 minor`

## Notes
- `bunx prettier --check ...` was not used because fetching the package manifest failed locally with `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`; repository-native guardrails and manifest/YAML checks were used instead.
- Merging this PR to `main` should trigger the release automation workflow for paths covered by `.github/workflows/release-plz.yml`. Creating the GitHub Release itself remains tied to the configured workflow behavior/manual dispatch path.