### PR TITLE
docs: tighten contribution governance and sops guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/architecture_rfc.yml
@@ -1,0 +1,59 @@
+name: Architecture RFC
+description: Discuss a high-risk architecture or policy change
+title: "RFC: "
+labels:
+  - rfc
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for high-risk architecture, policy, topology, contract, event, gate, or default runtime changes.
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Proposed decision
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What future rewrite, correctness gap, or ROI issue does this address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should this RFC explicitly not change?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: affected
+    attributes:
+      label: Affected boundaries
+      options:
+        - label: Service boundary
+        - label: Public contracts
+        - label: Event contracts
+        - label: Topology profile
+        - label: Secrets strategy
+        - label: Gate matrix
+        - label: Agent protocol
+        - label: Release promise
+        - label: Default runtime dependencies
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or experiments needed
+      description: Which executable checks, prototypes, gates, or operational evidence would make this safe to adopt?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,38 @@ body:
       value: |
         Thanks for reporting a bug. Please provide enough detail to reproduce.
 
+  - type: dropdown
+    id: user_type
+    attributes:
+      label: User type
+      description: Are you using the template, or contributing to the upstream repository?
+      options:
+        - Template user
+        - Upstream contributor / maintainer
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Getting started / setup
+        - Local development
+        - Template init
+        - Counter reference chain
+        - Contracts / generated artifacts
+        - Services
+        - Servers / BFF
+        - Workers / replay / delivery
+        - Platform model / topology
+        - Secrets / SOPS / GitOps
+        - Frontend or desktop shell
+        - Other
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/contribution_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/contribution_proposal.yml
@@ -1,0 +1,64 @@
+name: Contribution proposal
+description: Propose an upstream change before opening a PR
+title: "proposal: "
+labels:
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this before opening an upstream PR when the change is not a small, obvious Core Path patch.
+
+  - type: dropdown
+    id: path
+    attributes:
+      label: Contribution path
+      options:
+        - Core Path
+        - Reference Chain
+        - Topology Profile
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or invariant
+      description: What problem does this solve? What invariant does it protect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Which paths do you expect to change?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: risk
+    attributes:
+      label: Risk areas
+      options:
+        - label: Public API contract
+        - label: Event contract
+        - label: Idempotency / CAS / outbox semantics
+        - label: Tenant / auth boundary
+        - label: Topology default
+        - label: Gate matrix
+        - label: Generated artifacts
+        - label: Directory semantics
+        - label: Default runtime dependency
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Expected evidence
+      description: Which tests, gates, or scripts should prove this change?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,19 @@ body:
     attributes:
       value: |
         Thanks for the suggestion. Keep it focused, evidence-based, and aligned with the repository boundaries.
+        If this is an upstream implementation proposal, consider using "Contribution proposal" instead.
+        If this is a high-risk architecture or policy change, use "Architecture RFC" instead.
+
+  - type: dropdown
+    id: user_type
+    attributes:
+      label: User type
+      options:
+        - Template user
+        - Upstream contributor / maintainer
+        - Not sure
+    validations:
+      required: true
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/template_user_question.yml
+++ b/.github/ISSUE_TEMPLATE/template_user_question.yml
@@ -1,0 +1,54 @@
+name: Template user question
+description: Ask about using axum-harness as a template
+title: "template: "
+labels:
+  - template-user
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for questions about adopting the template in your own project.
+        For upstream contribution proposals, use "Contribution proposal" instead.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Getting started
+        - template-init
+        - Local development
+        - Backend-core cleanup
+        - Secrets / SOPS
+        - Counter-service reference chain
+        - Release / versioning
+        - Optional app shells
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe the project outcome you want, not only the command that failed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands run
+      render: shell
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Relevant output or error
+      render: shell
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Optional details such as OS, target runtime, backend-only needs, single VPS, K3s, or team requirements.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,97 @@
-## What changed
+## Contribution Path
+
+Choose one:
+
+- [ ] Core Path
+- [ ] Reference Chain
+- [ ] Topology Profile
+
+## Summary
+
+What changed?
 
 - 
 
-## Why
+## Problem / Invariant
+
+What problem does this solve, or what invariant does it protect?
 
 - 
 
-## How to verify
+## Risk Level
 
-- [ ] `just typecheck`
-- [ ] `just test`
-- [ ] `just boundary-check`
-- [ ] `just verify`
+- [ ] Low
+- [ ] Medium
+- [ ] High
 
-## Checklist
+High-risk areas include:
 
-- [ ] Scope is focused and minimal
-- [ ] No secrets or machine-local paths introduced
-- [ ] Docs updated if user-facing behavior changed
-- [ ] Boundaries in `AGENTS.md` and `agent/codemap.yml` still hold
+- public API contracts
+- event contracts
+- idempotency / CAS / outbox semantics
+- tenant / auth boundaries
+- topology defaults
+- gate matrix
+- generated artifact rules
+- directory semantics
+- default runtime dependencies
+
+## Evidence Level
+
+- [ ] declared
+- [ ] checked
+- [ ] tested
+- [ ] proven
+
+Use these terms consistently:
+
+- `declared`: metadata or prose only
+- `checked`: schema validation, static validation, typecheck, drift check, or boundary check
+- `tested`: unit, integration, contract, replay, resilience, or end-to-end tests
+- `proven`: executed gate or test evidence appropriate for the claimed invariant
+
+## Verification
+
+Commands run:
+
+```bash
+# paste exact commands
+```
+
+Result summary:
+
+```text
+# paste result summary
+```
+
+Commands not run and why:
+
+```text
+# paste here
+```
+
+Only claim checks passed if they actually ran in this change context.
+
+## Contract / Event / Topology / Gate Impact
+
+- [ ] Changes public API contracts
+- [ ] Changes event contracts
+- [ ] Changes generated artifacts
+- [ ] Changes topology profiles
+- [ ] Changes gate behavior
+- [ ] Changes service ownership
+- [ ] Changes default runtime dependencies
+- [ ] None of the above
+
+## Agent Use
+
+- [ ] No agent was used
+- [ ] Agent was used; output was reviewed by a human maintainer/contributor
+
+If an agent was used, summarize what it changed and what you verified manually.
+
+## Reviewer Focus
+
+What should reviewers inspect most carefully?
+
+- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,195 @@
-# Contributing
+# Contributing to axum-harness
 
-Thanks for your interest in contributing.
+This guide is for people contributing to the upstream `axum-harness` template.
 
-This repository is a backend-first Rust reference architecture with a built-in multi-agent harness. The fastest way to contribute successfully is to follow the existing boundaries instead of treating the repo like a generic monorepo.
+If you are using this repository as a template for your own project, start with `docs/template-users/README.md` instead. Template users do not need to preserve every upstream maintainer document, GitHub template, release automation file, or agent governance artifact in their derived project.
 
-## Before you start
+## Before You Start
 
-- Read `README.md` for the project overview.
-- Read `AGENTS.md` for the repository protocol.
-- Read `agent/codemap.yml` for ownership boundaries and anti-patterns.
-- Read `docs/operations/counter-service-reference-chain.md` before changing backend architecture patterns.
+Read these first:
 
-## Who this guide is for
+1. `README.md`
+2. `AGENTS.md`
+3. `agent/codemap.yml`
+4. `agent/manifests/gate-matrix.yml`
+5. `docs/operations/counter-service-reference-chain.md`
 
-This file is for people contributing to the template itself.
+This repository is not a generic monorepo. It is a backend-first Rust reference architecture with a built-in multi-agent harness. Successful contributions follow the existing boundaries instead of bypassing them.
 
-If you are using the repository via GitHub "Use this template", the repository release and README are your primary contract. You do not need to preserve every contributor-facing doc or research artifact in your derived project.
+## Contribution Paths
 
-## Ground rules
+Every issue or PR should choose one path.
 
-- Keep changes small and reversible.
-- Prefer evidence from code, validators, and gates over prose.
-- Do not hand-edit generated directories such as `platform/catalog/**`, `docs/generated/**`, `infra/kubernetes/rendered/**`, or generated SDK output.
-- Do not introduce product-specific business logic under the name of a generic pattern improvement.
-- Secrets must never be committed in plaintext. Use SOPS-based flows, not `.env` files, for backend secrets.
-- Put temporary private task notes, local refactor checklists, and scratch guidance under `docs/_local/`; it is gitignored by design.
-- Only commit docs that are meant to remain useful to future contributors or template users.
-- Follow `docs/governance/docs-lifecycle.md` when deciding whether a document should stay tracked, move to archive, or remain local-only.
+### Core Path
 
-## Development setup
+Use this for small, low-risk improvements.
+
+Good examples:
+
+- Rust cleanup
+- tests
+- docs hygiene
+- local developer workflow
+- small `counter-service` readability improvements
+- contract drift or generated artifact checks that do not change public shapes
+
+Expected evidence:
+
+- relevant tests or checks
+- no change to public contracts, topology defaults, event semantics, or gate behavior unless explicitly stated
+
+### Reference Chain
+
+Use this for changes to the serious backend reference path.
+
+Examples:
+
+- idempotency
+- CAS
+- transactional outbox
+- outbox relay
+- projector
+- replay/rebuild
+- event envelope
+- counter-service correctness
+
+Expected evidence:
+
+- invariant-focused tests
+- relevant strict gates when distributed semantics change
+- clear failure semantics
+
+### Topology Profile
+
+Use this for deployment and cross-cutting infrastructure.
+
+Examples:
+
+- SOPS
+- Kustomize
+- Flux
+- K3s
+- Podman or container packaging
+- NATS
+- Valkey
+- OpenTelemetry
+- platform model topology
+- runbooks
+
+Expected evidence:
+
+- profile or topology classification
+- validation command output
+- no claim of production readiness unless proven by executed gates and operational evidence
+
+## Risk Levels
+
+Low-risk changes:
+
+- typo fixes
+- docs hygiene
+- local scripts that do not change default runtime behavior
+- tests that do not change behavior
+- small internal refactors
+
+Medium-risk changes:
+
+- service internals
+- contracts implementation without public shape changes
+- generated checks
+- platform model validation
+- worker internals without new replay, delivery, or idempotency semantics
+
+High-risk changes:
+
+- public API contracts
+- event contracts
+- idempotency / CAS / outbox semantics
+- tenant / auth boundaries
+- topology defaults
+- gate matrix
+- generated artifact rules
+- directory semantics
+- default runtime dependencies
+
+High-risk changes should open an issue or RFC before a PR.
+
+## Evidence Levels
+
+Use these terms consistently:
+
+- `declared`: written in metadata or docs; useful for navigation, not evidence of behavior
+- `checked`: validated by a schema, static validator, drift check, typecheck, or boundary check
+- `tested`: exercised by unit, integration, contract, replay, resilience, or end-to-end tests
+- `proven`: supported by an explicit gate or test run that is appropriate for the claimed invariant and cited in the change record
+
+Do not claim a gate passed unless it actually ran in this change context.
+
+## Runtime Minimalism, Semantic Completeness
+
+The default runtime path should stay small enough for ordinary local development and single-VPS adoption, but the architecture must not become primitive.
+
+A mature cross-cutting tool may be absent from the inner-loop runtime and still be important to the reference chain. Do not delete valid topology, profile, adapter, or capability-slot work just because it is not enabled in `local-dev`.
+
+The rule is:
+
+- semantic boundary early
+- adapter seam early
+- local substitute early
+- real runtime profile when justified
+- no business-code rewrite when enabling the real tool
+
+## Capability Slots
+
+A capability slot is a stable home for a cross-cutting capability. It can include an interface, metadata, config shape, local substitute, real adapter, profile mapping, and verification command.
+
+Capability slots do not mean every real runtime dependency is required by default. They also do not mean a declared future capability is production-proven.
+
+Examples:
+
+- messaging: `EventBus`, `EventEnvelope`, `event_outbox`, memory/NATS adapters, relay gates
+- projection: replayable source, checkpoint, rebuildable read model, projector gates
+- secrets: SOPS templates, `just sops-run`, Kustomize/Flux overlays, delivery gates
+- auth/authz: principal, tenant scope, authorizer port, local/mock and real provider adapters
+
+## Hard Rules
+
+Do not:
+
+- weaken gates to pass CI
+- hand-edit generated artifacts
+- delete directionally correct topology/profile work because it is not used in local dev
+- introduce product-specific business logic as a generic template improvement
+- claim semantic correctness from YAML or docs alone
+- turn future intent into current fact
+- change public contracts, event semantics, topology defaults, service ownership, or default runtime dependencies without prior discussion
+- make frontend, desktop, release, production, or platform-full gates mandatory for ordinary backend-core changes unless the risk justifies it
+
+Generated directories are read-only. Change the source and regenerate instead.
+
+## Change Order
+
+Use the existing repository order of operations:
+
+1. If the platform schema cannot express the change, update `platform/schema/**` first.
+2. Update `platform/model/**` for platform-level metadata and topology.
+3. Update `services/<name>/model.yaml` for service-local semantics.
+4. Update `packages/contracts/**` before implementation when API/event shapes change.
+5. Then update `services/**`, `servers/**`, `workers/**`, and related verification.
+
+If a change crosses multiple domains, preserve the existing boundaries rather than collapsing everything into one patch.
+
+## Where Changes Belong
+
+- `platform/**`: platform model, validators, generators, topology, infrastructure metadata
+- `packages/contracts/**`: contracts and source-of-truth protocol types
+- `services/**`: domain logic and service-local semantics
+- `servers/**`: sync protocol adaptation and entrypoints
+- `workers/**`: async execution, replay, checkpoint, recovery
+- `apps/**`: optional frontend shells, not the default backend entry
+- `docs/**`: durable guidance for template users, contributors, maintainers, operators, or architecture decisions
+
+## Development Setup
 
 ```bash
 just setup
@@ -43,32 +204,9 @@ For local backend runs that need secrets, use SOPS-based injection:
 just sops-run DEPLOYABLE=web-bff ENV=dev
 ```
 
-## Change order
-
-Use the existing repository order of operations:
-
-1. If the platform schema cannot express the change, update `platform/schema/**` first.
-2. Update `platform/model/**` for platform-level metadata and topology.
-3. Update `services/<name>/model.yaml` for service-local semantics.
-4. Update `packages/contracts/**` before implementation when API/event shapes change.
-5. Then update `services/**`, `servers/**`, `workers/**`, and related verification.
-
-## Where changes belong
-
-- `platform/**` - platform model, validators, generators
-- `packages/contracts/**` - contracts and source-of-truth protocol types
-- `services/**` - domain logic and service-local semantics
-- `servers/**` - sync protocol adaptation and entrypoints
-- `workers/**` - async execution, replay, checkpoint, recovery
-- `apps/**` - optional frontend shells, not the default backend entry
-
-If a change crosses multiple domains, preserve the existing boundaries rather than collapsing everything into one patch.
-
 ## Validation
 
-Run the smallest relevant validation set for your change, then run the global gate before merging.
-
-Desktop/Tauri is not part of the default CI contract for this repository. If your change touches `apps/desktop/**` or desktop-specific runtime behavior, run the desktop commands explicitly on the target OS instead of assuming the backend CI lanes cover it.
+Run the smallest relevant validation set for your change, then escalate only when path, risk, or reviewer request justifies it.
 
 Common commands:
 
@@ -80,25 +218,54 @@ just contracts-check strict
 just verify
 ```
 
-Heavier platform, replay, delivery, and release gates are selected by changed paths, risk, and evidence level. Do not run or require them for every ordinary backend-core change.
-
 Gate-selection guidance is available here:
 
 ```bash
 bun run scripts/run-scoped-gates.ts --list
 ```
 
-Only claim checks passed if you actually ran them.
+Heavier platform, replay, delivery, and release gates are selected by changed paths, risk, and evidence level. Do not run or require them for every ordinary backend-core change.
 
-## Pull requests
+Desktop/Tauri is not part of the default CI contract for this repository. If your change touches `apps/desktop/**` or desktop-specific runtime behavior, run the desktop commands explicitly on the target OS instead of assuming the backend CI lanes cover it.
 
-- Explain what changed and why.
-- Include exact verification commands you ran.
-- Keep PRs focused.
-- Update docs when behavior, workflows, or operator expectations change.
-- Avoid unrelated cleanup in the same PR.
+## Pull Requests
 
-## Commit and release semantics
+Every PR should declare:
+
+- contribution path
+- problem or invariant
+- risk level
+- evidence level
+- exact commands run
+- commands not run and why
+- contract, event, topology, generated artifact, gate, ownership, or default runtime impact
+- reviewer focus
+
+Keep PRs focused. Avoid unrelated cleanup in the same PR.
+
+## Good First Contribution Areas
+
+Good first PRs usually touch:
+
+- tests
+- docs hygiene
+- local dev clarity
+- small Rust cleanup
+- issue reproduction
+- counter-service readability
+- generated artifact checks
+- small command-surface improvements
+
+Avoid starting with:
+
+- new services
+- new default infrastructure
+- large architecture rewrites
+- auth provider changes
+- topology default changes
+- release process changes
+
+## Commit and Release Semantics
 
 - This repository is versioned as one template product using repository-level SemVer.
 - Follow the latest repository tag/release as the active template line until there is a deliberate reason to open a new pre-1.0 line or to declare `1.0.0` stability.
@@ -107,24 +274,20 @@ Only claim checks passed if you actually ran them.
 - If a change alters template defaults, project layout, setup flow, or migration expectations for template users, call that out explicitly in the PR description and release notes.
 - If a change is only contributor-facing or internal, keep the commit message clear so `release-plz` changelogs stay readable.
 
-## Release process
+`release-plz` prepares repository releases and updates the root `CHANGELOG.md`. Most binaries/internal crates are configured with `publish = false`, so release automation can still generate changelogs and GitHub releases without requiring every crate to publish to crates.io.
 
-- This repository uses `release-plz` for repository release preparation.
-- Maintainers should prefer conventional commits such as `feat:`, `fix:`, and `docs:` so generated changelogs stay readable.
-- If you derive a new repository from this template, bootstrap the first official repository release manually with your chosen starting tag; after that, let release automation continue from that baseline.
-- `release-plz` opens a release PR on `main` and prepares version/changelog updates from merged commits.
-- Most binaries/internal crates are configured with `publish = false`, so release automation can still generate changelogs and GitHub releases without requiring every crate to publish to crates.io.
-- The SemVer contract users should rely on first is the repository tag/release, because this repo is primarily shipped as a template rather than as a set of independently consumed crates.
-- Cargo crate versions are still required for workspace tooling, but they are not independent product version promises.
-- Use `just semver-check` locally when validating repository-level compatibility assumptions for the current template line.
-- Default release automation uses `v{{ version }}`, but maintainers can override the tag template, detection glob, and bootstrap baseline through repository variables or `workflow_dispatch` inputs.
+## Reporting Bugs and Features
 
-## Reporting bugs and features
+Use the GitHub issue templates. Pick the template that matches your role:
 
-- Use the GitHub issue templates.
-- For security issues, use the private contact in `.github/ISSUE_TEMPLATE/config.yml` instead of opening a public issue.
+- template user question
+- bug report
+- contribution proposal
+- architecture RFC
 
-## Code of conduct
+For security issues, use the private contact in `.github/ISSUE_TEMPLATE/config.yml` instead of opening a public issue.
+
+## Code of Conduct
 
 By participating in this project, you agree to follow `CODE_OF_CONDUCT.md`.
 

--- a/README.md
+++ b/README.md
@@ -120,20 +120,41 @@ apps/              Optional frontend shells (web, desktop, mobile); removable fo
 packages/ui/       Optional shared UI package; not part of the backend reference chain
 ```
 
-## Who This Repo Is For
+## Choose Your Path
 
-There are two primary user modes for this repository:
+This repository serves two groups. Start with the path that matches your goal.
 
-1. **Template users** — teams that want to click "Use this template" and start a backend project from a pre-structured foundation.
-2. **Contributors / maintainers** — people who want to evolve the template itself, improve the architecture, and keep the repository publishable as an open-source project.
+### I want to use this as a template
+
+Start here:
+
+1. `docs/template-users/README.md`
+2. `docs/operations/local-dev.md`
+3. `docs/operations/secret-management.md`
+4. `docs/operations/counter-service-reference-chain.md`
+5. `docs/template-users/template-init.md`
 
 Template users should treat the repository release as the main contract and keep only the parts relevant to their project.
 
-The release strategy is repository-level SemVer for the template as a whole. Cargo crate versions remain internal workspace metadata, not separate product release channels.
+A dedicated `just template-init` cleanup flow exists for derived projects. The `backend-core` profile treats `apps/**` and `packages/ui/**` as optional shell surface that can be removed after reviewing the dry-run output.
+
+You do not need to preserve all upstream maintainer docs, GitHub issue templates, PR templates, release automation, or agent governance files in your derived project.
+
+### I want to contribute to axum-harness itself
+
+Start here:
+
+1. `CONTRIBUTING.md`
+2. `AGENTS.md`
+3. `agent/codemap.yml`
+4. `docs/operations/counter-service-reference-chain.md`
+5. `docs/governance/maintainer-decision-guide.md`
 
 Contributors should treat the repository structure, gates, agent protocol, and documentation conventions as part of the design, not as optional extras.
 
-A dedicated `just template-init` cleanup flow exists for derived projects. The `backend-core` profile treats `apps/**` and `packages/ui/**` as optional shell surface that can be removed after reviewing the dry-run output.
+Issues and PRs should declare their contribution path, risk level, and evidence level.
+
+The release strategy is repository-level SemVer for the template as a whole. Cargo crate versions remain internal workspace metadata, not separate product release channels.
 
 The root backend-core contract does not require SvelteKit, Tauri, mobile shells, or `packages/ui`. App shells may exist in the repository, but they are not part of the root development, verification, or code generation surface.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,8 @@ For maintainers and agent-assisted development:
 2. `docs/architecture/harness-philosophy.md`
 3. `agent/codemap.yml`
 4. `docs/adr/**`
-5. `docs/governance/docs-lifecycle.md`
+5. `docs/governance/maintainer-decision-guide.md`
+6. `docs/governance/docs-lifecycle.md`
 
 ## What Belongs Here
 

--- a/docs/governance/maintainer-decision-guide.md
+++ b/docs/governance/maintainer-decision-guide.md
@@ -1,0 +1,122 @@
+# Maintainer Decision Guide
+
+Use this guide to triage issues and PRs without relying on ad hoc architectural judgment.
+
+The goal is not to make every change heavy. The goal is to make user type, contribution path, risk, evidence, and merge criteria explicit.
+
+## Step 1: Identify the User Type
+
+Is this from:
+
+1. a template user; or
+2. an upstream contributor / agent?
+
+Template-user questions should not be forced through upstream contribution rules.
+
+Upstream changes must declare path, risk, and evidence.
+
+If unclear, ask for classification before reviewing implementation details.
+
+## Step 2: Classify the Contribution Path
+
+Use one path:
+
+- Core Path
+- Reference Chain
+- Topology Profile
+
+If unclear, label `needs-classification` and request a narrower scope.
+
+Core Path is for small, low-risk improvements such as docs hygiene, tests, local workflow, Rust cleanup, and small internal refactors.
+
+Reference Chain is for backend correctness changes around `counter-service`, contracts, CAS, idempotency, transactional outbox, relay, projector, replay, rebuild, and read models.
+
+Topology Profile is for deployment and cross-cutting infrastructure such as SOPS, Kustomize, Flux, K3s, NATS, Valkey, observability, platform model topology, and runbooks.
+
+## Step 3: Classify Risk
+
+Low risk:
+
+- docs hygiene
+- tests that do not change behavior
+- local workflow that does not change default runtime dependencies
+- small internal refactor
+
+Medium risk:
+
+- service internals
+- contracts implementation without public shape changes
+- generated checks
+- platform validation
+- worker internals without new distributed semantics
+
+High risk:
+
+- public API contracts
+- event contracts
+- idempotency
+- CAS
+- outbox
+- tenant/auth
+- topology defaults
+- gate matrix
+- directory semantics
+- generated artifact rules
+- default runtime dependencies
+
+High-risk changes require a prior issue, contribution proposal, or architecture RFC before merge.
+
+## Step 4: Check Evidence
+
+Use these terms:
+
+- `declared`: metadata or prose only
+- `checked`: schema validation, static validation, typecheck, drift check, or boundary check
+- `tested`: unit, integration, contract, replay, resilience, or end-to-end tests
+- `proven`: executed gate or test evidence appropriate for the claimed invariant
+
+Do not merge high-risk changes with only declared evidence.
+
+Do not accept claims that a gate passed unless the PR lists the exact command and result from this change context.
+
+## Step 5: Check Forbidden Moves
+
+Reject or request changes if the PR:
+
+- weakens gates to pass CI
+- hand-edits generated artifacts
+- deletes valid topology/profile/capability-slot work without classification
+- changes defaults without discussion
+- claims unrun gates passed
+- turns future intent into current fact
+- introduces product-specific logic as generic template design
+- makes non-default frontend, desktop, production, release, or platform-full gates mandatory for ordinary backend-core changes
+
+## Step 6: Check Runtime Minimalism And Semantic Completeness
+
+Do not interpret single-VPS friendliness as no workers, no outbox, no contracts, no telemetry, no secrets discipline, no deployment model, or no future topology path.
+
+Do not interpret microservice readiness as all distributed tools running by default.
+
+The expected balance is:
+
+- default runtime path stays lightweight
+- semantic boundaries remain explicit
+- local substitutes exist for inner-loop development
+- real adapters and runtime profiles are enabled when justified
+- enabling a real tool should not rewrite business code
+
+## Step 7: Merge Rule
+
+Merge only when:
+
+- user type is clear
+- contribution path is clear
+- risk is acceptable
+- evidence matches risk
+- docs do not overclaim
+- gates are not weakened
+- generated artifacts were not hand-edited
+- the PR reduces uncertainty
+
+If these are not true, request changes or redirect to an issue/RFC.

--- a/docs/operations/counter-service-reference-chain.md
+++ b/docs/operations/counter-service-reference-chain.md
@@ -420,13 +420,13 @@ counter 链路要求：
 
 新增后端 service 时，默认按以下路径执行，不给 agent 摇摆空间：
 
-1. 建立  作为 service-local semantics 真理源。
-2. 默认按 counter-service 的 DDD 分层：, , , 。
-3. 默认持久化走 ，不引入额外存储抽象。
-4. mutation 成功后写统一 （schema 由  拥有），不创建私有  表。
-5. service 不直接碰 broker（EventBus / PubSub），只写 outbox。
-6. outbox-relay 负责从  异步发布到 EventBus + PubSub。
-7. projection 必须 replayable / rebuildable，从  做 checkpoint。
-8. 跨 service 长事务必须 workflow 化。
-9. stub / future 包必须在  和  中标记 。
-10. 默认完成后至少通过 （含 , , , ）。
+1. 建立 `services/<name>/model.yaml` 作为 service-local semantics 真理源。
+2. 默认按 `counter-service` 的 DDD 分层：`domain/`、`application/`、`ports/`、`infrastructure/`。
+3. 默认持久化走 `LibSqlPort` / repository adapter，不引入额外存储抽象，除非先说明 capability slot 和验证边界。
+4. mutation 成功后写统一 `event_outbox`，schema 由 `packages/messaging` 拥有，不创建私有 `<service>_outbox` 表。
+5. service 不直接碰 broker runtime（NATS / PubSub）；service 只负责事务性状态变更与 outbox write。
+6. `workers/outbox-relay` 负责从 `event_outbox` 异步发布到当前消息骨干。
+7. projection 必须 replayable / rebuildable，默认从 `event_outbox` 做 replay source 和 checkpoint。
+8. 跨 service 长事务必须 workflow 化，不用同步调用伪装成分布式事务。
+9. stub / future 包必须在 `model.yaml`、README 或平台元数据中标记当前成熟度，不能写成已生产完备。
+10. 默认完成后至少运行 path-scoped guardrails；涉及 contract、replay、delivery、topology 或 P0 correctness 时按 `agent/manifests/gate-matrix.yml` 升级验证。

--- a/docs/operations/local-dev.md
+++ b/docs/operations/local-dev.md
@@ -36,6 +36,23 @@
 5. `infra/local/scripts/bootstrap.sh`
 6. `infra/local/scripts/bootstrap-auth.sh`
 
+## 2.1 平台前置条件
+
+当前仓库的本地后端主链并不是“所有命令在三平台纯原生完全等价”。更准确的理解是：
+
+1. macOS / Linux：当前是最接近仓库默认脚本假设的平台。
+2. Windows：Rust / Bun / Node / just / moon 本身可以原生运行，但本地 infra、SOPS shell 脚本、Podman compose、以及部分 Unix CLI 依赖当前更适合放在 `WSL2` 或 `Git Bash` 环境里执行。
+3. 如果目标是“单机启动并跑通默认后端链”，当前最稳的跨平台收敛方式是：
+   - 应用与测试命令：`just` / `moon` / `cargo`
+   - infra / SOPS / auth bootstrap：统一通过 POSIX shell 环境执行
+
+当前已经确认的现实约束：
+
+1. `just dev-api`、`just verify-backend-primary`、`just test-backend-primary` 这类 `cargo` / `moon` 主链命令更接近跨平台。
+2. `bash infra/local/scripts/bootstrap.sh ...`、`bash infra/local/scripts/bootstrap-auth.sh ...`、`just sops-run ...` 仍依赖 `bash`、`find`、`grep`、`sed`、`pkill`、`curl`、`jq`、`yq`、`sops` 等 Unix 工具链假设。
+3. `bootstrap-auth.sh` 当前硬编码使用 `podman compose`，并依赖 `podman cp` 与固定容器命名形状，因此它不是 Windows PowerShell 原生脚本。
+4. 这意味着当前文档应把 Windows 支持表述为“可行，但建议 WSL2/Git Bash + Podman machine”，而不是“所有 shell 下无差别原生支持”。
+
 ## 3. 当前真实入口
 
 ### 3.1 工具链准备

--- a/docs/operations/secret-management.md
+++ b/docs/operations/secret-management.md
@@ -75,6 +75,25 @@ just sops-show-age-key
 
 然后更新根目录 `.sops.yaml` 中对应环境的 public key。
 
+当前建议立刻再跑一次：
+
+```bash
+just sops-validate
+```
+
+这条命令现在应同时回答四件事：
+
+1. `.sops.yaml` 是否存在。
+2. `~/.config/sops/age/key.txt` 是否存在。
+3. 当前 age public key 是否真的出现在 `.sops.yaml` 的 `creation_rules` 中。
+4. 当前 key 是否真的能解开至少一个 `infra/security/sops/dev/*.enc.yaml` 文件。
+
+如果这里失败，优先按下面顺序判断：
+
+1. 没有 key：先执行 `just sops-gen-age-key`。
+2. key 存在，但 `.sops.yaml` 里没有对应 public key：执行 `just sops-show-age-key`，然后把 public key 写入 `.sops.yaml`。
+3. key 和 `.sops.yaml` 看起来一致，但仍无法解密：说明当前 `.enc.yaml` 很可能不是用这把 key 加密的，需要重新加密或切换到正确私钥。
+
 ### 3.2 编辑或生成某个 deployable 的 secrets
 
 推荐命令：
@@ -108,6 +127,29 @@ just sops-verify-counter-shared-db ENV=dev
 1. 让本地进程消费和集群一致的环境变量形状。
 2. 避免为了开发临时制造新的 `.env` 主路径。
 3. 在继续依赖当前已启用的独立 worker overlay 前，先验证 shared remote DB secret 不再指向本地 `file:` 路径。
+
+推荐的快速验证链：
+
+```bash
+just sops-validate
+just sops-verify-counter-shared-db ENV=dev
+bash infra/security/sops/scripts/decrypt-env.sh infra/security/sops/dev/web-bff.enc.yaml
+just sops-run DEPLOYABLE=web-bff ENV=dev
+```
+
+其中：
+
+1. `just sops-validate` 验证 key 与 `.sops.yaml`、以及样例解密是否真实可用。
+2. `just sops-verify-counter-shared-db ENV=dev` 验证 shared DB secret 是否仍残留模板占位符，是否错误指向本地 `file:` URL。
+3. `decrypt-env.sh` 可直接观察当前会注入哪些环境变量。
+4. `just sops-run` 则是最终运行态验证。
+
+当前常见失败信号及含义：
+
+1. `Age key not found`：本机还没有 `~/.config/sops/age/key.txt`。
+2. `Age public key is not present in .sops.yaml`：本机私钥对应的 public key 没被加入仓库 SOPS 规则。
+3. `failed to decrypt`：仓库内的 `.enc.yaml` 不是用当前私钥加密，或 `SOPS_AGE_KEY_FILE` 指向了错误文件。
+4. `REPLACE_WITH_TURSO_TOKEN`：模板占位符还没被真实 secret 替换，不应继续把这份 secret 当成可运行配置。
 
 ## 4. 与 Kustomize / Flux 的关系
 

--- a/infra/local/scripts/bootstrap.sh
+++ b/infra/local/scripts/bootstrap.sh
@@ -64,7 +64,7 @@ start_services() {
     
     # Check service health
     local unhealthy=0
-    for container in $("COMPOSE_CMD" -f "$COMPOSE_FILE" -p "$PROJECT_NAME" ps -q); do
+    for container in $($COMPOSE_CMD -f "$COMPOSE_FILE" -p "$PROJECT_NAME" ps -q); do
         local health=$($COMPOSE_CMD -f "$COMPOSE_FILE" -p "$PROJECT_NAME" ps --format json | grep -o '"Health":"[^"]*"' | cut -d'"' -f4)
         if [[ "$health" == "unhealthy" ]]; then
             unhealthy=1

--- a/justfiles/sops.just
+++ b/justfiles/sops.just
@@ -112,11 +112,46 @@ sops-validate:
     fi
     @echo "✓ .sops.yaml exists"
     @if [ ! -f ~/.config/sops/age/key.txt ]; then \
-        echo "WARNING: Age key not found. Generate with: just sops-gen-age-key"; \
-    else \
-        echo "✓ Age key exists"; \
+        echo "ERROR: Age key not found. Generate with: just sops-gen-age-key"; \
+        exit 1; \
     fi
+    @echo "✓ Age key exists"
+    @KEY=$(grep '# public key:' ~/.config/sops/age/key.txt | sed 's/# public key: //'); \
+    if [ -z "$KEY" ]; then \
+        echo "ERROR: Could not read public key from ~/.config/sops/age/key.txt"; \
+        exit 1; \
+    fi; \
+    if grep -q "$KEY" .sops.yaml; then \
+        echo "✓ Age public key matches .sops.yaml"; \
+    else \
+        echo "ERROR: Age public key is not present in .sops.yaml"; \
+        echo "       Run: just sops-show-age-key"; \
+        echo "       Then update .sops.yaml creation_rules for the target environment"; \
+        exit 1; \
+    fi
+    @if ! command -v sops >/dev/null 2>&1; then \
+        echo "ERROR: sops is not installed. Run: mise install"; \
+        exit 1; \
+    fi
+    @if ! command -v yq >/dev/null 2>&1; then \
+        echo "ERROR: yq is not installed. Run: mise install"; \
+        exit 1; \
+    fi
+    @echo "✓ sops available"
+    @echo "✓ yq available"
     @find infra/security/sops -name "*.enc.yaml" | wc -l | tr -d ' ' | xargs -I{} echo "✓ Encrypted secrets: {} files"
+    @SAMPLE=$(find infra/security/sops/dev -name "*.enc.yaml" | sort | head -n 1); \
+    if [ -n "$SAMPLE" ]; then \
+        if bash infra/security/sops/scripts/decrypt-env.sh "$SAMPLE" >/dev/null; then \
+            echo "✓ Sample decrypt succeeded: $SAMPLE"; \
+        else \
+            echo "ERROR: Sample decrypt failed: $SAMPLE"; \
+            echo "       Check that ~/.config/sops/age/key.txt matches recipients in .sops.yaml"; \
+            exit 1; \
+        fi; \
+    else \
+        echo "WARNING: no dev encrypted secrets found under infra/security/sops/dev"; \
+    fi
     @echo ""
     @echo "SOPS configuration valid"
 


### PR DESCRIPTION
## Summary
- tighten upstream contribution governance with path/risk/evidence-driven PR and issue templates plus a maintainer decision guide
- split public entry points for template users vs upstream contributors and fix the damaged counter-service reference-chain onboarding section
- clarify current local-dev and SOPS guidance around platform assumptions, validation, and safer shell bootstrap expectations

## Verification
- `rtk just boundary-check`
- parsed `.github/ISSUE_TEMPLATE/*.yml` successfully with Bun + `yaml`

## Notes
- this PR includes the previously requested local SOPS/platform guidance updates alongside the governance/onboarding refactor
- heavier repo-wide verification was not run because the change is governance/docs/shell guidance scoped; boundary checks were run and passed