### PR TITLE
refactor(tooling): tighten repo-tools control plane

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,19 +13,21 @@
 # - gate-*     生命周期/治理门禁入口
 set export  # 导出环境变量到子进程
 
-# ── 模块导入 ────────────────────────────────────────────────
-# 生命周期主轴：setup -> dev -> build -> verify -> ops -> clean
-# 领域副轴：platform / sops / template / skills
-import? 'justfiles/setup.just'
-import? 'justfiles/dev.just'
-import? 'justfiles/build.just'
-import? 'justfiles/verify.just'
-import? 'justfiles/ops.just'
-import? 'justfiles/clean.just'
-import? 'justfiles/platform.just'
-import? 'justfiles/sops.just'
-import? 'justfiles/template.just'
-import? 'justfiles/skills.just'
+# 模块导入
+# justfiles/* 是命令面的一部分，不应静默缺失；这里保持显式导入和稳定顺序。
+# 主轴：setup -> dev -> build -> verify -> ops -> clean
+import 'justfiles/setup.just'
+import 'justfiles/dev.just'
+import 'justfiles/build.just'
+import 'justfiles/verify.just'
+import 'justfiles/ops.just'
+import 'justfiles/clean.just'
+
+# 副轴：platform / secrets / template / skills
+import 'justfiles/platform.just'
+import 'justfiles/sops.just'
+import 'justfiles/template.just'
+import 'justfiles/skills.just'
 
 # ── 默认行为 / 导航 ──────────────────────────────────────────
 
@@ -69,6 +71,7 @@ help-dev:
     @printf "  just status-dev               查看本地 infra 状态\n"
     @printf "  just logs-dev SERVICE=nats    跟随本地 infra 指定服务日志\n"
     @printf "  just dev-workers              启动本地 workers\n"
+    @printf "  just status-workers           查看 worker 后台运行状态\n"
     @printf "  just health-workers           查看 worker 健康状态\n"
     @printf "  just ps                       查看本地进程状态\n"
     @printf "\n"

--- a/agent/codemap.yml
+++ b/agent/codemap.yml
@@ -51,6 +51,71 @@ source_of_truth:
       - moon.yml
     note: Evidence comes from executable checks, not metadata declarations.
 
+modules:
+  services:
+    tenant-service:
+      path: services/tenant-service
+      status: implemented
+      notes: Tenant lifecycle and membership semantics.
+    user-service:
+      path: services/user-service
+      status: implemented
+      notes: User profile and tenant binding semantics.
+    auth-service:
+      path: services/auth-service
+      status: implemented
+      notes: Authentication application service semantics.
+    counter-service:
+      path: services/counter-service
+      status: implemented
+      notes: Default backend anchor and counter domain semantics.
+  servers:
+    web-bff:
+      path: servers/bff/web-bff
+      status: implemented
+      notes: HTTP BFF protocol adapter for default backend flows.
+    gateway:
+      path: servers/gateway
+      status: implemented
+      notes: Gateway entrypoint and routing surface.
+  workers:
+    projector:
+      path: workers/projector
+      status: implemented
+      notes: Projection worker with replay support.
+      must_have:
+        - replay_strategy
+    sync-reconciler:
+      path: workers/sync-reconciler
+      status: implemented
+      notes: Synchronization reconciliation worker.
+    scheduler:
+      path: workers/scheduler
+      status: implemented
+      notes: Scheduled job execution worker.
+    outbox-relay:
+      path: workers/outbox-relay
+      status: implemented
+      notes: Outbox polling and publishing worker.
+      must_have:
+        - dedupe
+    indexer:
+      path: workers/indexer
+      status: implemented
+      notes: Indexing worker entrypoint.
+
+rules:
+  required_files:
+    service:
+      - Cargo.toml
+      - src
+    server:
+      - Cargo.toml
+      - src
+    worker:
+      - Cargo.toml
+      - src
+
 layers:
   - name: root
     paths:

--- a/agent/manifests/routing-rules.yml
+++ b/agent/manifests/routing-rules.yml
@@ -129,6 +129,9 @@ rules:
   - match: "justfiles/**"
     primary: planner
 
+  - match: "tools/repo-tools/**"
+    primary: planner
+
   # Agent system itself
   - match: "agent/**"
     primary: planner

--- a/infra/security/sops/dev/web-bff.enc.yaml
+++ b/infra/security/sops/dev/web-bff.enc.yaml
@@ -1,44 +1,44 @@
-#ENC[AES256_GCM,data:IQVwMLeuZr5HXzwU6EXUIRbYYbcDpPzq2sE7kGQe8QYY,iv:AkW9EJ7Q6v6Va42LYgQ1i18rPiQyPYfwtUaTkJ2wSkQ=,tag:QHDQVLzgVkJd6Xt2y6PQxw==,type:comment]
+#ENC[AES256_GCM,data:/I1aHb7y9BzZBhiUEKYXD0FgjlgzI2M7pJCI0mqrA/vK,iv:9Ognxi8u7gaL8HCznCSBWvspPORQhwkn5hY0ZIGmhWA=,tag:aSjn+NqUDPEaNAM20ArKZQ==,type:comment]
 #
-#ENC[AES256_GCM,data:ecBIymU9cJ+fyVltcb8t+gg5FzJPfpqDKAewSf6WRofDJCNZKrS1VSUFWV10BKhBWk/7dA==,iv:QSap6Lt2Q1mf4KQ2RnFgefCclxwtoArxcKxZMXiWTr4=,tag:XSU+LRJvGhrif4v7TWz1MA==,type:comment]
-#ENC[AES256_GCM,data:f6cLmhfHGhfs5jSOZ2zjMNaf5RDqUd4m2lh6qgyMIyT9KNkfo7265VkBkz9sSgQ2TZfujlJzIPaBoALaatn1k2C+EM5w3IzvJ1IUcNvj8jZF4X9M,iv:hrfg5UUWRpUt7yjz0byRDH1ahjUqOSZikOqKi51BwEM=,tag:qHvu6XGsE/q8BU6pVZ2a8A==,type:comment]
+#ENC[AES256_GCM,data:D4rDUbNeFW+0LUxyPDM/ALQl5ixAV8mv9QyAEs9DdUieNKLBLclK33tArrjhBZgo6hHfCQ==,iv:5Ry/VgRxFY9oTGxTJgv2mcTTYpcB5g87K6v3Exli3xU=,tag:nP2tYlbVvfslFfJa2iHN2g==,type:comment]
+#ENC[AES256_GCM,data:sgRB08AVzblWXRtQArc1IcB9330Oi6lIrY7NZE1P27GHhZKgAjQdM4LRuHwDOSTMZzc2azp3qMUvWIezqgPbqudQjBLSTAqP2fSlHNpICKANmPXE,iv:s1Kc7WuYpngLdwyGLaUCjK+k/g/LxROBhE8n1R1kfw0=,tag:I3za5tdAod9dU4OgfOBXRw==,type:comment]
 #
-#ENC[AES256_GCM,data:OTlwOze6o4xo1Z9Lel+XsbUgEuO+R6ArCibTWZucgzdgSfzHz5BxD5UC9CPSCjdS86S7JaecEf8=,iv:dkgyHGdZfy9x9Lnd78NXZSHRvy3WJ4byanQ7bOcNbjg=,tag:NHtBYaDjYDgzld251iFNFw==,type:comment]
-apiVersion: ENC[AES256_GCM,data:ku0=,iv:i6SSu1fsd4Swx52ISfwNi3q3Q96XZWLfn++nsUd1c6Y=,tag:oqD99GqoRui0lCRrSzfWrA==,type:str]
-kind: ENC[AES256_GCM,data:WFkJ9xLl,iv:CLh5ihOfNJmBuezTK52s9POqDBQ5WdxqFtN5F8e9pjs=,tag:NfRzMbjx7N2TBUBmy8nuVg==,type:str]
+#ENC[AES256_GCM,data:2ugkiBACFtA2/2wgzf7jSDRGaTD6XB+yvdSiqNLsLPR1USopJziXwDzeiQNY4hqiDuE5abk63l4=,iv:SWIPiD8Gz4m41irAdqW5WU2BNuLR0fzYR6YKGi4568Y=,tag:N1uhoKZ3QNdGej80W0/isg==,type:comment]
+apiVersion: ENC[AES256_GCM,data:7i4=,iv:Fih8z7yeNgltja3/fpWW8314cEX0QRnovHty1m1eYCo=,tag:DuZjtZa6MDGQDlyz8Ln9ug==,type:str]
+kind: ENC[AES256_GCM,data:SYuU+Oxr,iv:e8aTmaDYqytKTYKDs5Kg5sF6rvqzr0tqy5pY5gkuqFI=,tag:lNaJX/Bi/jpZOcChrXgHsA==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:9cBFojlnIvhRg4nktllY,iv:/2r80n58lulP8yi0aHMMDXGF/PbFzBLzCZbbWjPicRQ=,tag:l4aKdmWt7lc5P3656XjOyw==,type:str]
-    namespace: ENC[AES256_GCM,data:PyUa,iv:gPkB8+umQbnctoriBnTLirNNtq3ExCk2IKLGwYPCdTc=,tag:m48DUjbPQC8UKx4+Zpz0JA==,type:str]
+    name: ENC[AES256_GCM,data:aJxU3MeRKJo0BeZeNBpq,iv:k6Hkc+pvuV66JvkwVIWz7lHOoV/Vp53rAicpGrxTQRU=,tag:iQbVDhn3HDQbLjR27BnH6w==,type:str]
+    namespace: ENC[AES256_GCM,data:8M1K,iv:tVIps+L8DMBjujE4VzpgYuvaw9iZtjJGrbCuTNgkwNU=,tag:ZVaRGO/M1dL1TqaotJcnUg==,type:str]
     labels:
-        app.kubernetes.io/name: ENC[AES256_GCM,data:DBI2FeCcWg==,iv:R+0AGuPYk4AJWPN7d2cAoF/bGfa5uGGW+MT2e2fTEtA=,tag:Mzu5gWyz0iRGZR9t96skxQ==,type:str]
-        app.kubernetes.io/env: ENC[AES256_GCM,data:fsUR,iv:57iTK3qcwlyE5SERwuzcO2SlK1dRnSvmc/IhIdJLS2s=,tag:atr6lqx3T+hGTfLFC46fbg==,type:str]
-type: ENC[AES256_GCM,data:OHPdT9er,iv:SPX1mVV9g01l26nIM2Oxdo02whekSGgVkeb2kbSufx8=,tag:FaKlRj4X+Br6YFt35i2hbw==,type:str]
+        app.kubernetes.io/name: ENC[AES256_GCM,data:7tPIlT7wCA==,iv:H2Hcxr4/MeaU1ph0vIhjdAY+kehdPDnuyg8XUoWCwnk=,tag:5hc3lNMvawXklZSuO6hr2w==,type:str]
+        app.kubernetes.io/env: ENC[AES256_GCM,data:Ku1F,iv:YwTLFmj1Gz7gY3jNqryz2vsJpHY46gJmuYzOYTxZPpI=,tag:xS2eBiezGZVWNQ+Dn4ZoyA==,type:str]
+type: ENC[AES256_GCM,data:QhUeTVME,iv:uSq79toIVFakC8EravX9RyHXtId4YarV/w/rLgN+V7I=,tag:d2DC+6BK2AtDAAZEFVI36Q==,type:str]
 stringData:
-    #ENC[AES256_GCM,data:w0cvgaxQlWJKKVqds2W8IoMV4fCB4QOAD528Sf+BspZehMffUmUnYCFK3eVKU6Z0aNeMmMk+2NbSYNryaTY3ZoDqCWb/ctaAaKjpMg6mO5rntqtDNL7wa5Jme9qt0eteTBFe2rk9up/qwo7hZSE1EDtfjAXXZ1B+8PZR81evsfDBEnAauva1jcxe/qb7B9W+QVqozKhSF+12Uuu2uB3V5b3u,iv:lrX1ynw+Ya1si8vXaFvlRb0c3cwikGw/y7QHlGa1xKg=,tag:vlrkYDHgn1TDEEn/oOCtKQ==,type:comment]
-    APP_SERVER_HOST: ENC[AES256_GCM,data:rYURDxqW+g==,iv:xRq41g1U27WpjaGjR95AEvtVELpad3mbYmeb1gN/kXg=,tag:T8+1TrQCXuNNBv2iLNGEnw==,type:str]
-    APP_SERVER_PORT: ENC[AES256_GCM,data:60v3ew==,iv:x4fgcBVBhU51mIYLUw1Q6w9b4iy/hAUDoIzuarzJ4ik=,tag:LxbwuuLhToKGYrsv9jOddA==,type:str]
-    APP_RUST_LOG: ENC[AES256_GCM,data:r8B5cSN65jpOsyFzH6pobclUrg==,iv:Wpei+rwlR8Ovjlm5avKzTJFJsvsqGNh2Gfvmmh9Lkrg=,tag:0NYCFlRZnCs19LSsAEb75A==,type:str]
-    #ENC[AES256_GCM,data:N+sSDZyYZErz37DSltnUk5W4xh0sc6Jz3HmavFSlLUSBLEyEGho1/IP5D5j1ODpbsubxyEwbV8aAoPai8UmL0Hey134VltzqLzEazXohnC3WjQig4FUORTn9zea/t7GzskfDurwbr0w/XUqKARFyK8kNF1G65Hda7zJcsQTDwGQYdeE4ixF7kkMh,iv:f9q53NRO58TQxcoqoG36cPEZXAMBfiV6+pBUQuEZdK0=,tag:iMfFIH8fANF3XKNbyg0UZg==,type:comment]
-    APP_JWT_SECRET: ENC[AES256_GCM,data:j7GrrJ5IDaq6GjUO5RkRCa4XtCBvPuee,iv:IooyCepm0+HypnktsaqvcVcG5Ol8do7rNSyljMc9sGY=,tag:QAsF3eijD4TTpv+sDQffkg==,type:str]
-    #ENC[AES256_GCM,data:7GjM4GKX4N+d+AkhgQf61yRkcfpB01PmtqUvlqjGFQwBGFM5UnxBgkMhnHKiYRaIosF3kQEUdkp52g8eXfSWCw0QGJjl3fzS7H2qZ7UXvkPG7ui39/PG19C4VXa8RhFe2rm0nqeg9zuAvhjlPDVXvmXLH2xQlRsL4craKomTNYDSxbWxDI/SSYvQcSjDIFOLtM8D2rKSza9AKPAhKn8Hh3vEiZsA5g==,iv:5FSWO8dwCrku0t4o9MAtKA4UVWxGshTI8cXt0rBTUOA=,tag:iEALgyt+WsSRFtvqPtWYow==,type:comment]
-    APP_CORS_ALLOWED_ORIGINS: ENC[AES256_GCM,data:QHaTmc2Lybab2+6s+bRnmLhzaCc8wZlWcd0o00NcT35J6y5y0yRQK/RLGA==,iv:TwAyjXlmoI/Eqy5flZUP7S6sp0S4jZAXBJO9iR2LIjg=,tag:E6WsHYgC9EIKG6pNLJrnnw==,type:str]
-    #ENC[AES256_GCM,data:0ME4S+sMKN+cSjDRVMW6M3UeDle/t/Tt0ICl9gKsiJ6NiMaBoEzs4+ISv3tQfcKNVTB55vC9dQokbO98UXcMc7aR,iv:XesR8edqL/KrNiNg+xazeK6Z9VDnGpRLsmpQjLo7TPs=,tag:nBrE2a4qboFqqrAgapd9iA==,type:comment]
-    APP_DATABASE_URL: ENC[AES256_GCM,data:q/ijfb5n/5DLb+pXGdkfWMo6zm/C,iv:rEN+V6j5gt5S8LW41jRFjmoWd0vt0TTjn3y+NcJmEkk=,tag:MuqBUQABsTOMWL1s52VUjQ==,type:str]
-#ENC[AES256_GCM,data:57Acl/lUsTcroqDynhF02bbxKy5zKWd4985f97C1SCOPOKBa2s6rCxDs9A/jKG1qjrSFD0gwpvnaV1MvlaqSgCcgCYg=,iv:8xZCmyYURgU0ugvOFGxMiIwfi5Dgfc/2ewl1Wk7Qj8c=,tag:P8Ht597e/RTydDkG8rdwVA==,type:comment]
-#ENC[AES256_GCM,data:gWx7u7oTUE/UfAIrOBCSW6Xq,iv:Z12Oat++PDbOSo5jHv5kHqhvTdnzvIVwnzW7BCmONl8=,tag:Hp4993kkax++cU/3qImopg==,type:comment]
-#ENC[AES256_GCM,data:73yGju0j+yBpl8d3mVq/T4RQm9NPAwFOqg==,iv:99Lyqcgw9FUwVg+ucJ3cZRoJl5rUzci/IGfXjpl79ls=,tag:CeK641bBPN/19x4HozucLQ==,type:comment]
+    #ENC[AES256_GCM,data:vJE5z/tLS/lv/u2qGDh4D31b0aAgIRHLASBdAuhiKNBTz8gk39EuBx9qx/Cakfl1zWmWard2ASP0MvjyVSumkSoCbciwVB5jKbRC3ECYhllWacR9qjwkBx7MHAPF8nxLSWWu4gHK70l/iTG38rrNM3iHA5FV/gtcMOqndXUgM10sayS6Q/45d4kfx7VRHfVUW2UI2Gmz2ab8hJ8d1VWWvgUw,iv:mLqjkHmgcc3eatlqPQ4h2Xjz1+N/J6l8W8NXMwWAxRg=,tag:/RVr1MH5NiZx2EMqcRjqBQ==,type:comment]
+    APP_SERVER_HOST: ENC[AES256_GCM,data:WNcyCy7hsg==,iv:yvcMuiSeRj4DRJ4TskmaRSqrFYVMc/Df2l28gnB3wh0=,tag:NiO3pI8np3FfECuH6iUEzw==,type:str]
+    APP_SERVER_PORT: ENC[AES256_GCM,data:rW78NQ==,iv:MNf9u4F0XCuG1BYtwRgDnwuKS9+ysOR0rWdeGZvH83I=,tag:s1Omu96tklw7N3XHmdv4VA==,type:str]
+    APP_RUST_LOG: ENC[AES256_GCM,data:OAGHMumCBBZxUlv59piZbc4ghQ==,iv:PUuJCGA85SdLg9s7z0s2WVScB7xXbWmsRJvVNXSBEgs=,tag:ceLwAk0bU7NxSRKmGQGxow==,type:str]
+    #ENC[AES256_GCM,data:gbhMlCEURFNBgJ16/8o4kvTFpgWAewdUmZLhl9IuUba8E0dWMseb0Va5ww7EyOCpbMoL+Tump9pmoC72sDXrRBRmqQbPcn+aAADuy4Wcq1l04UKUGQ8ulNq7OPcHItIzhL+yWfuRVBKN0TgaB3srUL3ap4NmrrAiRXqecWA3ywQ/laEVWv1yvLjd,iv:bI6ibU3JWRIO8lpFNVlZYFOhm0hGElSV8xW6F1tN/ns=,tag:pVoQd+UH5kuq2NM88sukIA==,type:comment]
+    APP_JWT_SECRET: ENC[AES256_GCM,data:XvDBBV40T3ACoRHTCrvwvTN2kV1deVSz,iv:wJQSZgjzkYImTP8mDGyEWeI/MEFBhh2dOrHXPYRKVnk=,tag:oUzNr0/7/Mqd8v/nRcIXSA==,type:str]
+    #ENC[AES256_GCM,data:Ta3+PRnzBmZfeSZfho8JlyOqZDVpQmxDouYKvoWufvkMmu+0aMc9V+hgK9g0Fc5TNgqDZDRaKmK8G+YJuVGImF8elNhQ9OteS2oilHaZEcRPOduqWspQUhh1FbNoqLPRaFx5ICZcYOV6oEX6HtWthUkIyzfamRfLeSMSZEhzRQNvP7pQ843PvkN4AGVvjerFewVFrEQLv7eisKfBTn5e9MqxUn+XhA==,iv:qE4UsBJTmdxjtQGjrsalJfoSUn/HTbNmHm9VPG98jvo=,tag:1XAgW2eIxpvr79OaqPQt0A==,type:comment]
+    APP_CORS_ALLOWED_ORIGINS: ENC[AES256_GCM,data:vXKiTBfLaBhfflm67WOGRAx7AZM8lyA5qcMjZK92gpcmtU1EfCgBwSqYIQ==,iv:naMK3IXKb6bLjkwLgj5h3RL6rq14Ivaye5Uozp0O6nY=,tag:h5zDV+TjD3yAPk/KqelyMw==,type:str]
+    #ENC[AES256_GCM,data:4hGlhcjU8IBfF5+TGAw8zBZEkDD7J6oqoeFLQwB9V6jfYfH+ni1ZYVWj42jytxHB2jsRQHnykcHS/us9yYEgwaIE,iv:r9YKzaWEu76QjC0ntLeuUbc04pC5ma+p4e8DP874hQs=,tag:zWQYbXuowqarioVpyHArLA==,type:comment]
+    APP_DATABASE_URL: ENC[AES256_GCM,data:JBugdyjHDymNpWDoc/XQ2zG/SGZr,iv:ootSH5rElG5kqds/q9j2j5E30HlWFxq9zShF3poIDLA=,tag:sBsiktfyQ8fnTcLbgCa34A==,type:str]
+#ENC[AES256_GCM,data:8U+QFEYHtbxaHWvzgUh3UL/hYQJ19TqFaolWLXjfuXwvJughHsKM+Gs5GbosjcoHsR+br0046H1dQ1wOqOZqMaaFiG0=,iv:zYa8RFoMp83M6q3L2zJqyPaivknSn8kZEhwJKhyUDjA=,tag:Y37Q0teIkieH2FVt9xpZmA==,type:comment]
+#ENC[AES256_GCM,data:ge6sRFAijWpQa9zYf4UIk6EB,iv:1Vn7jhrdQ+1Og9r5J4Ko0O3PLXy7PPkKCM9/x9mnyro=,tag:xeJnsdzEqEv4r+e7h2HB0w==,type:comment]
+#ENC[AES256_GCM,data:iqFNY8PDpXgY9xpXwPymT+3DkFHGoFpJZA==,iv:Wh01vOA9fkKWCiZVPx8ol6N53UXrDQTJaqBymSgHCKQ=,tag:aWami2ks01Al4Yjj+A9yGQ==,type:comment]
 sops:
     age:
         - recipient: age1p5v7s6gpq7grkdgldlguha9x3z79lgwl8vhwppwjs0xvng2g84rs8j67pm
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuZHErSXlwTEtTZ0IrUUJz
-            NkxHZ0RKamZkRll6QXFZSDhOalY3dWJOa3pzCmc5cldHbHV2RXVZL2V3ZUVNSllI
-            R3gvWFUzZTFJNEdOZVh0djVyejUvTjAKLS0tIDhpcGplSW1uc1BmRE5tWThlcDA5
-            MFZZb25hMkZKOUtCSkJjMkl1d2ZnVG8KDRp+f0gqD0owqzOtd1g8OpW4t0m+/Ocr
-            j3Jb2NFlRKPE0chKuc4qFM7/QdsN8AnmlmmVJR9jMS1wAzHV/qIt2A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxRlV1WmU0TW11SHcyNUw5
+            dG9mODJoU0ZsTDFtVlRDakdDdU5ISmxlU2tBCk1nMFFBbmhrbmZmSHRjR3FaZ2tB
+            Qmd3TWZ0aDFZaVJXT2U5WExKVkZrNW8KLS0tIDJOM0xMblROeGdWWExvMWNtTTll
+            NDloK1pjZ0FXbnltS05yYzBvUVNiTFEK4Krc0Q10Dau+pbZnUwA9i4h/D7J2+EK1
+            zfc1KCH5p9H3Lp/mhrCCmTh7enAVtrO/PA+mrgbot7efmfK64mi3AQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-16T11:09:59Z"
-    mac: ENC[AES256_GCM,data:H36aDcvzoO9qqmioUaovnlKXIWhVUI+ub1lMpeh37grSwDmOLMW9MBt7VYTmTh1TBI56+zsmDSl+9hCJ3QYtSmjeECJzQ49M3QTPBZtyyFNpk24XsL6cKi4BpdNdEfA1dAlkWzhxs6i+fV6AgMB741clx+buOFVo+W1OUlaNgnw=,iv:X1To8jO6u6aYLMUVEBBQ2Qfgo6ABN0uvEzKNdnipMPg=,tag:WrVF46ietiHL2PErwtkurg==,type:str]
+    lastmodified: "2026-04-30T04:40:29Z"
+    mac: ENC[AES256_GCM,data:onDfn//7fSSuSrPu1qv4ZJCNaG1grPNZqB5Mk+n/u/EFbpoVlm012MT+UDM+gF03NhMi94GIvHR2AwgO7YHfgsANGJoiazBV2Bk9/YbGnUYrAY1Yibrs4TBSpjEvfM+MTH9uiKjOUqrLVw2/QTM8eW14DU2MrdCHPpKDtADm3YQ=,iv:lxjLHLBU8HoGTn3l6+kAZ32bROgD4kzKbcKBsJz4xL4=,tag:VaM7il0VJhyMruOdyDT13A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/justfiles/dev.just
+++ b/justfiles/dev.just
@@ -25,9 +25,8 @@ deploy-dev:
 # 启动本地 core infra + observability
 deploy-dev-full:
     @echo "Starting dev infrastructure + observability..."
-    podman compose -f infra/docker/compose/app.yaml up -d
-    podman compose -f infra/docker/compose/observability.yaml up -d
-    @echo "OpenObserve UI: http://localhost:5080 (admin@localhost / admin)"
+    cargo run -p repo-tools -- infra local up
+    cargo run -p repo-tools -- infra local observability up
 
 # 启动本地 auth stack（Zitadel + OpenFGA）
 auth-up:
@@ -55,6 +54,7 @@ auth-logs:
 # 停止本地 core infra
 stop-dev:
     @echo "Stopping dev infrastructure..."
+    cargo run -p repo-tools -- infra local observability down
     cargo run -p repo-tools -- infra local down
 
 # 跟随本地 infra 指定服务日志
@@ -71,124 +71,42 @@ status-dev:
 
 # 查看本项目相关进程状态
 ps:
-    @echo "=== 项目进程状态 ==="
-    @echo ""
-    @echo "--- Web BFF Server (port 3010) ---"
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort 3010 -ErrorAction SilentlyContinue | Select-Object OwningProcess | Where-Object OwningProcess -gt 0 | ForEach-Object { Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue | Select-Object Id,ProcessName,StartTime }" 2>/dev/null || echo "  [STOPPED]"; \
-    else \
-        lsof -i :3010 2>/dev/null | grep LISTEN || echo "  [STOPPED]"; \
-    fi
-    @echo ""
-    @echo "--- 孤儿/无响应进程 ---"
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-Process | Where-Object { $_.Responding -eq $false } | Select-Object Id,ProcessName,Responding" 2>/dev/null || echo "  [NONE]"; \
-    else \
-        ps -axo user=,pid=,stat=,start=,time=,command= | awk '$3 ~ /^Z/ { print }' || echo "  [NONE]"; \
-    fi
+    cargo run -p repo-tools -- dev process status
 
 # 停止所有本项目启动的开发进程
 stop:
-    @echo "正在停止所有开发进程..."
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'cargo run' -or $_.ProcessName -match 'web-bff' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [BFF servers stopped]"; \
-        powershell -NoProfile -Command "Get-Process | Where-Object { $_.CommandLine -match 'moon run repo:dev' } | Stop-Process -Force -ErrorAction SilentlyContinue" 2>/dev/null; echo "  [moon tasks stopped]"; \
-    else \
-        pkill -f "cargo run -p web-bff" 2>/dev/null && echo "  ✓ Web BFF stopped" || echo "  - Web BFF not running"; \
-        pkill -f "web-bff" 2>/dev/null && echo "  ✓ web-bff stopped" || true; \
-        pkill -f "moon run repo:dev" 2>/dev/null && echo "  ✓ moon tasks stopped" || true; \
-    fi
-    @echo "清理完成"
+    cargo run -p repo-tools -- dev process stop
 
 # 停止指定端口的进程
 stop-port PORT='':
     @test -n "{{PORT}}" || (echo "Usage: just stop-port 3010" && exit 1)
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "$conn = Get-NetTCPConnection -LocalPort {{PORT}} -ErrorAction SilentlyContinue; if ($conn) { Stop-Process -Id $conn.OwningProcess -Force; echo '  ✓ Port {{PORT}} freed' } else { echo '  - Nothing on port {{PORT}}' }"; \
-    else \
-        PIDS=$(lsof -ti :{{PORT}} 2>/dev/null || true); \
-        if [ -n "$PIDS" ]; then \
-            kill -9 $PIDS 2>/dev/null && echo "  ✓ Port {{PORT}} freed" || echo "  - Failed to free port {{PORT}}"; \
-        else \
-            echo "  - Nothing on port {{PORT}}"; \
-        fi; \
-    fi
+    cargo run -p repo-tools -- dev process stop-port {{PORT}}
 
 # 清理当前用户的孤儿/无响应进程
 clean-orphans:
-    @echo "正在清理当前用户的孤儿/无响应进程..."
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-Process | Where-Object { $_.Responding -eq $false -and $_.SessionId -eq (Get-Process -Id $PID).SessionId } | Stop-Process -Force -ErrorAction SilentlyContinue; echo '  ✓ Non-responding processes cleaned'"; \
-    else \
-        PIDS=$(ps -axo pid=,stat= | awk '$2 ~ /^Z/ {print $1}'); \
-        if [ -n "$PIDS" ]; then \
-            kill -9 $PIDS 2>/dev/null && echo "  ✓ Zombie processes cleaned" || echo "  - Failed to clean zombie processes"; \
-        else \
-            echo "  - No zombie processes found"; \
-        fi; \
-    fi
-    @echo "完成"
+    cargo run -p repo-tools -- dev process clean-orphans
 
 # 显示端口占用详情
 ports:
-    @echo "=== 项目端口占用 ==="
-    @echo ""
-    @echo "Port 3010 (Web BFF):"
-    @if [ "{{os_family()}}" = "windows" ]; then \
-        powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort 3010 -ErrorAction SilentlyContinue | ForEach-Object { Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue | Select-Object Id,ProcessName }" 2>/dev/null || echo "  [FREE]"; \
-    else \
-        lsof -i :3010 2>/dev/null | grep -v COMMAND || echo "  [FREE]"; \
-    fi
+    cargo run -p repo-tools -- dev process ports
 
 # 启动所有 workers（后台运行）
 dev-workers:
-    @echo "Starting workers..."
-    @echo "  - outbox-relay-worker (health: :3030)"
-    @echo "  - indexer-worker (health: :3031)"
-    @echo "  - projector-worker (health: :3032)"
-    @echo "  - scheduler-worker (health: :3033)"
-    @echo "  - sync-reconciler-worker (health: :3034)"
-    @echo ""
-    @echo "Workers run in background. Use 'just stop-workers' to stop."
-    cargo run -p outbox-relay-worker &
-    cargo run -p indexer-worker &
-    cargo run -p projector-worker &
-    cargo run -p scheduler-worker &
-    cargo run -p sync-reconciler-worker &
-    @echo "All workers started."
+    cargo run -p repo-tools -- dev worker start
 
 # 停止所有 workers
 stop-workers:
-    @echo "Stopping workers..."
-    @pkill -f "outbox-relay-worker" 2>/dev/null && echo "  ✓ outbox-relay-worker stopped" || echo "  - outbox-relay-worker not running"
-    @pkill -f "indexer-worker" 2>/dev/null && echo "  ✓ indexer-worker stopped" || echo "  - indexer-worker not running"
-    @pkill -f "projector-worker" 2>/dev/null && echo "  ✓ projector-worker stopped" || echo "  - projector-worker not running"
-    @pkill -f "scheduler-worker" 2>/dev/null && echo "  ✓ scheduler-worker stopped" || echo "  - scheduler-worker not running"
-    @pkill -f "sync-reconciler-worker" 2>/dev/null && echo "  ✓ sync-reconciler-worker stopped" || echo "  - sync-reconciler-worker not running"
-    @echo "Done."
+    cargo run -p repo-tools -- dev worker stop
+
+# 查看 workers 后台运行状态
+status-workers:
+    cargo run -p repo-tools -- dev worker status
 
 # 启动单个 worker
 run-worker WORKER='':
     @test -n "{{WORKER}}" || (echo "Usage: just run-worker WORKER=outbox-relay" && exit 1)
-    @echo "Starting {{WORKER}}-worker..."
-    cargo run -p {{WORKER}}-worker
+    cargo run -p repo-tools -- dev worker run {{WORKER}}
 
 # 查看 workers 健康状态
 health-workers:
-    @echo "=== Worker Health ==="
-    @echo ""
-    @echo "outbox-relay-worker (:3030):"
-    @curl -s http://localhost:3030/healthz 2>/dev/null || echo "  [UNREACHABLE]"
-    @echo ""
-    @echo "indexer-worker (:3031):"
-    @curl -s http://localhost:3031/healthz 2>/dev/null || echo "  [UNREACHABLE]"
-    @echo ""
-    @echo "projector-worker (:3032):"
-    @curl -s http://localhost:3032/healthz 2>/dev/null || echo "  [UNREACHABLE]"
-    @echo ""
-    @echo "scheduler-worker (:3033):"
-    @curl -s http://localhost:3033/healthz 2>/dev/null || echo "  [UNREACHABLE]"
-    @echo ""
-    @echo "sync-reconciler-worker (:3034):"
-    @curl -s http://localhost:3034/healthz 2>/dev/null || echo "  [UNREACHABLE]"
-    @echo ""
+    cargo run -p repo-tools -- dev worker health

--- a/justfiles/ops.just
+++ b/justfiles/ops.just
@@ -24,20 +24,15 @@ deploy-bootstrap-vps:
 
 # 在目标服务器上部署并启动 axum API 服务
 deploy-api:
-    @systemctl is-active --quiet axum-api.service && echo "API service is running" || echo "API service will be started"
-    sudo systemctl daemon-reload
-    sudo systemctl enable axum-api.service
-    sudo systemctl restart axum-api.service
-    sudo systemctl status axum-api --no-pager
+    cargo run -p repo-tools -- ops service deploy --service axum-api
 
 # 停止 API 服务
 stop-api:
-    sudo systemctl stop axum-api.service
-    @echo "API service stopped"
+    cargo run -p repo-tools -- ops service stop --service axum-api
 
 # 查看 API 服务日志
 logs-api:
-    sudo journalctl -u axum-api.service -f --no-pager
+    cargo run -p repo-tools -- ops service logs --service axum-api
 
 # 生成 systemd service 文件（需在目标服务器执行）
 generate-service BIN_PATH='' ENV_FILE='' USER='root' GROUP='root':
@@ -61,15 +56,8 @@ migrate-status:
 
 # 创建新的 migration 文件
 migrate-create NAME='':
-    @if [ -z "{{NAME}}" ]; then \
-        echo "Usage: just migrate-create add_counter_index"; \
-        exit 1; \
-    fi
-    @TIMESTAMP=$(date +%Y%m%d%H%M%S); \
-    MIGRATION_FILE="ops/migrations/api/${TIMESTAMP}_{{NAME}}.sql"; \
-    mkdir -p ops/migrations/api; \
-    touch "$MIGRATION_FILE"; \
-    echo "Created migration: $MIGRATION_FILE"
+    @test -n "{{NAME}}" || (echo "Usage: just migrate-create add_counter_index" && exit 1)
+    cargo run -p repo-tools -- dev migration create "{{NAME}}"
 
 # 重置数据库（仅限开发环境，危险操作）
 migrate-reset:

--- a/justfiles/setup.just
+++ b/justfiles/setup.just
@@ -65,4 +65,4 @@ setup-coverage:
 
 # 检查工具链版本
 toolchain-check:
-    rustc --version && moon --version && echo "ALL OK"
+    cargo run -p repo-tools -- toolchain-check

--- a/justfiles/skills.just
+++ b/justfiles/skills.just
@@ -6,67 +6,54 @@
 
 # List all installed skills
 skills-list:
-    @echo "=== Installed AI Skills ==="
-    @bunx skills list
-    @echo ""
-    @echo "💡 Add more skills: just skills-add <github-repo-or-url>"
+    cargo run -p repo-tools -- dev skills list
 
 # Search for available skills
 skills-find QUERY='':
     @if [ -z "{{QUERY}}" ]; then \
-        bunx skills find; \
+        cargo run -p repo-tools -- dev skills find; \
     else \
-        bunx skills find "{{QUERY}}"; \
+        cargo run -p repo-tools -- dev skills find "{{QUERY}}"; \
     fi
 
 # Check for skill updates
 skills-check:
-    @echo "=== Checking for Skill Updates ==="
-    @bunx skills check
+    cargo run -p repo-tools -- dev skills check
 
 # ── Installation ───────────────────────────────────────────
 
 # Add skills from GitHub/GitLab/local directory
 skills-add SOURCE='':
     @test -n "{{SOURCE}}" || (echo "Usage: just skills-add <github-repo-or-url>" && echo "Examples:" && echo "  just skills-add vercel-labs/agent-skills" && echo "  just skills-add https://github.com/owner/repo" && echo "  just skills-add ./path/to/skill" && exit 1)
-    @echo "=== Adding Skill: {{SOURCE}} ==="
-    @bunx skills add "{{SOURCE}}"
+    cargo run -p repo-tools -- dev skills add "{{SOURCE}}"
 
 # Add specific skill from a repository (skip others)
 skills-add-specific SOURCE='' SKILL='':
     @test -n "{{SOURCE}}" || (echo "Usage: just skills-add-specific <repo> <skill-name>" && exit 1)
     @test -n "{{SKILL}}" || (echo "Usage: just skills-add-specific <repo> <skill-name>" && exit 1)
-    @echo "=== Adding Specific Skill: {{SKILL}} from {{SOURCE}} ==="
-    @bunx skills add "{{SOURCE}}" -s "{{SKILL}}"
+    cargo run -p repo-tools -- dev skills add-specific "{{SOURCE}}" "{{SKILL}}"
 
 # Update all installed skills
 skills-update:
-    @echo "=== Updating All Skills ==="
-    @bunx skills update
+    cargo run -p repo-tools -- dev skills update
 
 # ── Management ──────────────────────────────────────────────
 
 # Remove a skill
 skills-remove SKILL='':
     @test -n "{{SKILL}}" || (echo "Usage: just skills-remove <skill-name>" && echo "Available skills:" && bunx skills list && exit 1)
-    @echo "=== Removing Skill: {{SKILL}} ==="
-    @bunx skills remove "{{SKILL}}"
+    cargo run -p repo-tools -- dev skills remove "{{SKILL}}"
 
 # Initialize a new custom skill template
 skills-init NAME='':
     @test -n "{{NAME}}" || (echo "Usage: just skills-init <skill-name>" && exit 1)
-    @echo "=== Creating Skill: {{NAME}} ==="
-    @bunx skills init "{{NAME}}"
-    @echo ""
-    @echo "💡 Edit the template at: .agents/skills/{{NAME}}/SKILL.md"
+    cargo run -p repo-tools -- dev skills init "{{NAME}}"
 
 # ── Information ─────────────────────────────────────────────
 
 # Show skill status and directory structure
 skills-status:
-    @echo "=== Skills Directory Structure ==="
-    @echo ""
-    @bunx skills list
+    cargo run -p repo-tools -- dev skills status
 
 # Show documentation
 skills-help:

--- a/justfiles/sops.just
+++ b/justfiles/sops.just
@@ -15,61 +15,27 @@
 
 # Generate a new age key pair
 sops-gen-age-key:
-    @mkdir -p ~/.config/sops/age
-    @if [ -f ~/.config/sops/age/key.txt ]; then \
-        echo "WARNING: Age key already exists at ~/.config/sops/age/key.txt"; \
-        echo "Current public key:"; \
-        grep "# public key:" ~/.config/sops/age/key.txt | sed 's/# public key: //' || true; \
-        echo ""; \
-        echo "Set confirm=y to overwrite: just sops-gen-age-key confirm=y"; \
-        exit 1; \
-    fi
-    @age-keygen -o ~/.config/sops/age/key.txt
-    @echo ""
-    @echo "✓ Age key generated: ~/.config/sops/age/key.txt"
-    @echo "Public key:"
-    @grep "# public key:" ~/.config/sops/age/key.txt | sed 's/# public key: //'
-    @echo ""
-    @echo "Next steps:"
-    @echo "  1. Copy the public key above"
-    @echo "  2. Update .sops.yaml with the public key for each environment"
-    @echo "  3. Back up ~/.config/sops/age/key.txt securely"
+    cargo run -p repo-tools -- dev age-key generate
 
 # Show age public key
 sops-show-age-key:
-    @if [ ! -f ~/.config/sops/age/key.txt ]; then \
-        echo "ERROR: Age key not found. Generate one with: just sops-gen-age-key"; \
-        exit 1; \
-    fi
-    @echo "Age public key:"
-    @grep "# public key:" ~/.config/sops/age/key.txt | sed 's/# public key: //'
-    @echo ""
-    @echo "Key file: ~/.config/sops/age/key.txt"
+    cargo run -p repo-tools -- dev age-key show
 
 # ── Secrets Encryption ──────────────────────────────────────
 
 # Encrypt secrets for dev environment
 sops-encrypt-dev DEPLOYABLE='web-bff':
-    @echo "Encrypting secrets for deployable: {{DEPLOYABLE}} (dev)"
-    @sops --encrypt --input-type yaml --output-type yaml \
-        "infra/security/sops/templates/dev/{{DEPLOYABLE}}.yaml" \
-        > "infra/security/sops/dev/{{DEPLOYABLE}}.enc.yaml"
-    @echo "✓ Encrypted: infra/security/sops/dev/{{DEPLOYABLE}}.enc.yaml"
-    @echo "Commit this file to Git"
+    cargo run -p repo-tools -- secrets encrypt --deployable "{{DEPLOYABLE}}" --env dev
 
 # Encrypt secrets for staging environment
 sops-encrypt-staging DEPLOYABLE='web-bff':
-    @echo "Encrypting secrets for deployable: {{DEPLOYABLE}} (staging)"
-    @sops --encrypt "infra/security/sops/templates/staging/{{DEPLOYABLE}}.yaml" > "infra/security/sops/staging/{{DEPLOYABLE}}.enc.yaml"
-    @echo "✓ Encrypted: infra/security/sops/staging/{{DEPLOYABLE}}.enc.yaml"
+    cargo run -p repo-tools -- secrets encrypt --deployable "{{DEPLOYABLE}}" --env staging
 
 # ── Secrets Editing ─────────────────────────────────────────
 
 # Edit encrypted secrets (opens editor with decrypted content)
 sops-edit DEPLOYABLE='web-bff' ENV='dev':
-    @echo "Editing: {{DEPLOYABLE}} ({{ENV}})"
-    @sops "infra/security/sops/{{ENV}}/{{DEPLOYABLE}}.enc.yaml"
-    @echo "✓ Saved (encrypted in place)"
+    cargo run -p repo-tools -- secrets edit --deployable "{{DEPLOYABLE}}" --env "{{ENV}}"
 
 # ── Local Development (No Cluster) ──────────────────────────
 
@@ -89,17 +55,7 @@ sops-reconcile ENV='dev':
 
 # Create Flux SOPS secret (age key in cluster)
 sops-setup-flux-secret:
-    @if [ ! -f ~/.config/sops/age/key.txt ]; then \
-        echo "ERROR: Age key not found. Generate one with: just sops-gen-age-key"; \
-        exit 1; \
-    fi
-    @echo "Creating Flux SOPS secret in flux-system namespace"
-    @kubectl create secret generic sops-age \
-        --namespace flux-system \
-        --from-file=age.agekey=~/.config/sops/age/key.txt \
-        --dry-run=client -o yaml | kubectl apply -f -
-    @echo "✓ Flux SOPS secret created"
-    @echo "Flux will now be able to decrypt SOPS-encrypted secrets"
+    cargo run -p repo-tools -- secrets setup-flux-secret
 
 # ── Validation ──────────────────────────────────────────────
 

--- a/justfiles/verify.just
+++ b/justfiles/verify.just
@@ -205,41 +205,19 @@ k6-baseline BASE_URL='http://localhost:3010' DURATION='30s' VUS='5':
 
 # Trivy 漏洞扫描（默认扫描整个项目文件系统，可指定 IMAGE）
 scan-vuln IMAGE='' EXIT_CODE='0':
-    @if [ -n "{{IMAGE}}" ]; then \
-        echo "=== Trivy image scan: {{IMAGE}} ===" ; \
-        trivy image --severity HIGH,CRITICAL --exit-code {{EXIT_CODE}} {{IMAGE}} ; \
-    else \
-        echo "=== Trivy filesystem scan ===" ; \
-        trivy fs --severity HIGH,CRITICAL --exit-code {{EXIT_CODE}} {{justfile_directory()}} ; \
-    fi
+    cargo run -p repo-tools -- scan-vuln --image "{{IMAGE}}" --exit-code {{EXIT_CODE}}
 
 # Syft SBOM 生成（默认生成 JSON 格式，输出到 stdout 或文件）
 gen-sbom IMAGE='' FORMAT='json' OUTPUT='-':
-    @if [ -n "{{IMAGE}}" ]; then \
-        echo "=== Syft SBOM: image {{IMAGE}} ===" ; \
-        if [ "{{OUTPUT}}" = "-" ]; then \
-            syft {{IMAGE}} -o {{FORMAT}} ; \
-        else \
-            syft {{IMAGE}} -o {{FORMAT}}={{OUTPUT}} ; \
-        fi ; \
-    else \
-        echo "=== Syft SBOM: workspace ===" ; \
-        if [ "{{OUTPUT}}" = "-" ]; then \
-            syft dir:{{justfile_directory()}} -o {{FORMAT}} ; \
-        else \
-            syft dir:{{justfile_directory()}} -o {{FORMAT}}={{OUTPUT}} ; \
-        fi ; \
-    fi
+    cargo run -p repo-tools -- gen-sbom --image "{{IMAGE}}" --format "{{FORMAT}}" --output "{{OUTPUT}}"
 
 # Cosign 镜像签名（需要 COSIGN_EXPERIMENTAL=1 时用 keyless 模式）
 sign-image IMAGE:
-    @echo "=== Cosign sign: {{IMAGE}} ==="
-    cosign sign {{IMAGE}}
+    cargo run -p repo-tools -- sign-image {{IMAGE}}
 
 # Cosign 镜像验证
 verify-image IMAGE:
-    @echo "=== Cosign verify: {{IMAGE}} ==="
-    cosign verify {{IMAGE}}
+    cargo run -p repo-tools -- verify-image {{IMAGE}}
 
 # 一键跑全量供应链检查（本地 gate）
 supply-chain:

--- a/tools/repo-tools/src/cli.rs
+++ b/tools/repo-tools/src/cli.rs
@@ -57,10 +57,16 @@ enum Commands {
     PlatformDeployables,
     PlatformResources,
     CleanSdk,
+    Dev(DevArgs),
     Apps(AppsArgs),
     Secrets(SecretsArgs),
     Infra(InfraArgs),
     Ops(OpsArgs),
+    ToolchainCheck,
+    ScanVuln(ScanVulnArgs),
+    GenSbom(GenSbomArgs),
+    SignImage(ImageRefArgs),
+    VerifyImage(ImageRefArgs),
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -227,6 +233,146 @@ pub(crate) struct K6BaselineArgs {
 }
 
 #[derive(Args)]
+pub(crate) struct DevArgs {
+    #[command(subcommand)]
+    pub(crate) command: DevCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DevCommand {
+    AgeKey(DevAgeKeyArgs),
+    Process(DevProcessArgs),
+    Migration(DevMigrationArgs),
+    Worker(DevWorkerArgs),
+    Skills(DevSkillsArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct DevAgeKeyArgs {
+    #[command(subcommand)]
+    pub(crate) command: DevAgeKeyCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DevAgeKeyCommand {
+    Generate(DevAgeKeyGenerateArgs),
+    Show,
+}
+
+#[derive(Args)]
+pub(crate) struct DevAgeKeyGenerateArgs {
+    #[arg(long)]
+    pub(crate) overwrite: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct DevProcessArgs {
+    #[command(subcommand)]
+    pub(crate) command: DevProcessCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DevProcessCommand {
+    Status,
+    Ports,
+    Stop,
+    StopPort(DevStopPortArgs),
+    CleanOrphans,
+}
+
+#[derive(Args)]
+pub(crate) struct DevStopPortArgs {
+    pub(crate) port: u16,
+}
+
+#[derive(Args)]
+pub(crate) struct DevMigrationArgs {
+    #[command(subcommand)]
+    pub(crate) command: DevMigrationCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DevMigrationCommand {
+    Create(DevCreateMigrationArgs),
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct DevCreateMigrationArgs {
+    pub(crate) name: String,
+}
+
+#[derive(Args)]
+pub(crate) struct DevWorkerArgs {
+    #[command(subcommand)]
+    pub(crate) command: DevWorkerCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DevWorkerCommand {
+    Start(DevWorkerStartArgs),
+    Stop,
+    Status,
+    Health,
+    Run(DevWorkerRunArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct DevWorkerStartArgs {
+    #[arg(long)]
+    pub(crate) attach: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct DevWorkerRunArgs {
+    pub(crate) worker: String,
+}
+
+#[derive(Args)]
+pub(crate) struct DevSkillsArgs {
+    #[command(subcommand)]
+    pub(crate) command: DevSkillsCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum DevSkillsCommand {
+    List,
+    Find(DevSkillsFindArgs),
+    Check,
+    Add(DevSkillsAddArgs),
+    AddSpecific(DevSkillsAddSpecificArgs),
+    Update,
+    Remove(DevSkillsRemoveArgs),
+    Init(DevSkillsInitArgs),
+    Status,
+}
+
+#[derive(Args)]
+pub(crate) struct DevSkillsFindArgs {
+    pub(crate) query: Option<String>,
+}
+
+#[derive(Args)]
+pub(crate) struct DevSkillsAddArgs {
+    pub(crate) source: String,
+}
+
+#[derive(Args)]
+pub(crate) struct DevSkillsAddSpecificArgs {
+    pub(crate) source: String,
+    pub(crate) skill: String,
+}
+
+#[derive(Args)]
+pub(crate) struct DevSkillsRemoveArgs {
+    pub(crate) skill: String,
+}
+
+#[derive(Args)]
+pub(crate) struct DevSkillsInitArgs {
+    pub(crate) name: String,
+}
+
+#[derive(Args)]
 pub(crate) struct SecretsArgs {
     #[command(subcommand)]
     pub(crate) command: SecretsCommand,
@@ -238,6 +384,9 @@ pub(crate) enum SecretsCommand {
     VerifyCounterSharedDb(SecretsEnvArgs),
     Run(SecretsRunArgs),
     Reconcile(SecretsReconcileArgs),
+    Encrypt(SecretsEncryptArgs),
+    Edit(SecretsEditArgs),
+    SetupFluxSecret,
     Validate,
 }
 
@@ -271,6 +420,22 @@ pub(crate) struct SecretsReconcileArgs {
 }
 
 #[derive(Args)]
+pub(crate) struct SecretsEncryptArgs {
+    #[arg(long, default_value = "web-bff")]
+    pub(crate) deployable: String,
+    #[arg(long, default_value = "dev")]
+    pub(crate) env: String,
+}
+
+#[derive(Args)]
+pub(crate) struct SecretsEditArgs {
+    #[arg(long, default_value = "web-bff")]
+    pub(crate) deployable: String,
+    #[arg(long, default_value = "dev")]
+    pub(crate) env: String,
+}
+
+#[derive(Args)]
 pub(crate) struct InfraArgs {
     #[command(subcommand)]
     pub(crate) command: InfraCommand,
@@ -295,6 +460,7 @@ pub(crate) enum InfraLocalCommand {
     Down(InfraLocalDownArgs),
     Status(InfraLocalStatusArgs),
     Logs(InfraLocalLogsArgs),
+    Observability(InfraObservabilityArgs),
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -347,6 +513,52 @@ pub(crate) struct InfraLocalStatusArgs {
 
 #[derive(Args)]
 pub(crate) struct InfraLocalLogsArgs {
+    #[arg(long, value_enum)]
+    pub(crate) runtime: Option<ContainerRuntime>,
+    #[arg(long)]
+    pub(crate) service: Option<String>,
+    #[arg(long, short)]
+    pub(crate) follow: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct InfraObservabilityArgs {
+    #[command(subcommand)]
+    pub(crate) command: InfraObservabilityCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum InfraObservabilityCommand {
+    Up(InfraObservabilityUpArgs),
+    Down(InfraObservabilityDownArgs),
+    Status(InfraObservabilityStatusArgs),
+    Logs(InfraObservabilityLogsArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct InfraObservabilityUpArgs {
+    #[arg(long, value_enum)]
+    pub(crate) runtime: Option<ContainerRuntime>,
+    #[arg(long, default_value_t = true, action = ArgAction::Set)]
+    pub(crate) detach: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct InfraObservabilityDownArgs {
+    #[arg(long, value_enum)]
+    pub(crate) runtime: Option<ContainerRuntime>,
+}
+
+#[derive(Args)]
+pub(crate) struct InfraObservabilityStatusArgs {
+    #[arg(long, value_enum)]
+    pub(crate) runtime: Option<ContainerRuntime>,
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct InfraObservabilityLogsArgs {
     #[arg(long, value_enum)]
     pub(crate) runtime: Option<ContainerRuntime>,
     #[arg(long)]
@@ -425,6 +637,57 @@ pub(crate) struct OpsArgs {
 pub(crate) enum OpsCommand {
     Migrate(OpsMigrateArgs),
     BootstrapVps(OpsBootstrapVpsArgs),
+    Service(OpsServiceArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct OpsServiceArgs {
+    #[command(subcommand)]
+    pub(crate) command: OpsServiceCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum OpsServiceCommand {
+    Deploy(OpsServiceNameArgs),
+    Stop(OpsServiceNameArgs),
+    Logs(OpsServiceLogsArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct OpsServiceNameArgs {
+    #[arg(long, default_value = "axum-api")]
+    pub(crate) service: String,
+}
+
+#[derive(Args)]
+pub(crate) struct OpsServiceLogsArgs {
+    #[arg(long, default_value = "axum-api")]
+    pub(crate) service: String,
+    #[arg(long, short, default_value_t = true, action = ArgAction::Set)]
+    pub(crate) follow: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct ScanVulnArgs {
+    #[arg(long, default_value = "")]
+    pub(crate) image: String,
+    #[arg(long, default_value_t = 0)]
+    pub(crate) exit_code: i32,
+}
+
+#[derive(Args)]
+pub(crate) struct GenSbomArgs {
+    #[arg(long, default_value = "")]
+    pub(crate) image: String,
+    #[arg(long, default_value = "json")]
+    pub(crate) format: String,
+    #[arg(long, default_value = "-")]
+    pub(crate) output: String,
+}
+
+#[derive(Args)]
+pub(crate) struct ImageRefArgs {
+    pub(crate) image: String,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -543,9 +806,15 @@ pub(crate) fn run() -> Result<()> {
         Commands::PlatformDeployables => commands::platform::list_platform_inventory("deployables"),
         Commands::PlatformResources => commands::platform::list_platform_inventory("resources"),
         Commands::CleanSdk => commands::platform::clean_sdk(),
+        Commands::Dev(args) => commands::devx::run_dev(args),
         Commands::Apps(args) => commands::apps::run(args),
         Commands::Secrets(args) => commands::secrets::run(args),
         Commands::Infra(args) => commands::infra::run(args),
         Commands::Ops(args) => commands::ops::run(args),
+        Commands::ToolchainCheck => commands::doctor::toolchain_check(),
+        Commands::ScanVuln(args) => commands::devx::scan_vuln(args),
+        Commands::GenSbom(args) => commands::devx::gen_sbom(args),
+        Commands::SignImage(args) => commands::devx::sign_image(args),
+        Commands::VerifyImage(args) => commands::devx::verify_image(args),
     }
 }

--- a/tools/repo-tools/src/commands/devx.rs
+++ b/tools/repo-tools/src/commands/devx.rs
@@ -1,14 +1,913 @@
+use anyhow::{Context, Result, bail};
+use reqwest::blocking::Client;
+use serde_json::Value;
 use std::fs;
-
-use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use xshell::{Shell, cmd};
 
-use crate::cli::{GenerateServiceArgs, K6BaselineArgs, RequireToolArgs};
+use crate::cli::{
+    DevAgeKeyArgs, DevAgeKeyCommand, DevArgs, DevCommand, DevCreateMigrationArgs, DevMigrationArgs,
+    DevMigrationCommand, DevProcessArgs, DevProcessCommand, DevSkillsAddArgs,
+    DevSkillsAddSpecificArgs, DevSkillsArgs, DevSkillsCommand, DevSkillsFindArgs,
+    DevSkillsInitArgs, DevSkillsRemoveArgs, DevStopPortArgs, DevWorkerArgs, DevWorkerCommand,
+    DevWorkerRunArgs, DevWorkerStartArgs, GenSbomArgs, GenerateServiceArgs, ImageRefArgs,
+    K6BaselineArgs, RequireToolArgs, ScanVulnArgs,
+};
 use crate::support;
 use crate::support::{
-    collect_files_with_extension, has_tool, normalize_slashes, read, require_tool, run_capture,
-    run_inherit, workspace_root, write,
+    Operation, OperationPhase, collect_files_with_extension, has_tool, normalize_slashes, read,
+    require_tool, run_capture, run_inherit, user_home_dir, workspace_root, write,
 };
+
+const AGE_KEY_RELATIVE_PATH: &str = ".config/sops/age/key.txt";
+const SKILLS_RUNNER: &str = "bunx";
+const SKILLS_CLI: &str = "skills";
+const DEFAULT_STOP_PATTERNS: &[&str] = &["cargo run -p web-bff", "web-bff", "moon run repo:dev"];
+const WORKER_STATE_DIR: &str = ".tmp/dev/workers";
+const WORKERS: &[WorkerSpec] = &[
+    WorkerSpec::new("outbox-relay", 3030),
+    WorkerSpec::new("indexer", 3031),
+    WorkerSpec::new("projector", 3032),
+    WorkerSpec::new("scheduler", 3033),
+    WorkerSpec::new("sync-reconciler", 3034),
+];
+
+pub(crate) fn run_dev(args: DevArgs) -> Result<()> {
+    match args.command {
+        DevCommand::AgeKey(args) => run_age_key(args),
+        DevCommand::Process(args) => run_process(args),
+        DevCommand::Migration(args) => run_migration(args),
+        DevCommand::Worker(args) => run_worker(args),
+        DevCommand::Skills(args) => run_skills(args),
+    }
+}
+
+fn run_age_key(args: DevAgeKeyArgs) -> Result<()> {
+    match args.command {
+        DevAgeKeyCommand::Generate(args) => generate_age_key(args.overwrite),
+        DevAgeKeyCommand::Show => show_age_key(),
+    }
+}
+
+fn run_process(args: DevProcessArgs) -> Result<()> {
+    match args.command {
+        DevProcessCommand::Status => process_status(),
+        DevProcessCommand::Ports => process_ports(),
+        DevProcessCommand::Stop => stop_default_processes(),
+        DevProcessCommand::StopPort(args) => stop_port(args),
+        DevProcessCommand::CleanOrphans => clean_orphans(),
+    }
+}
+
+fn run_migration(args: DevMigrationArgs) -> Result<()> {
+    match args.command {
+        DevMigrationCommand::Create(args) => create_migration(args),
+    }
+}
+
+fn run_worker(args: DevWorkerArgs) -> Result<()> {
+    match args.command {
+        DevWorkerCommand::Start(args) => start_workers(args),
+        DevWorkerCommand::Stop => stop_workers(),
+        DevWorkerCommand::Status => worker_status(),
+        DevWorkerCommand::Health => worker_health(),
+        DevWorkerCommand::Run(args) => run_single_worker(args),
+    }
+}
+
+fn run_skills(args: DevSkillsArgs) -> Result<()> {
+    match args.command {
+        DevSkillsCommand::List => skills_list(),
+        DevSkillsCommand::Find(args) => skills_find(args),
+        DevSkillsCommand::Check => skills_check(),
+        DevSkillsCommand::Add(args) => skills_add(args),
+        DevSkillsCommand::AddSpecific(args) => skills_add_specific(args),
+        DevSkillsCommand::Update => skills_update(),
+        DevSkillsCommand::Remove(args) => skills_remove(args),
+        DevSkillsCommand::Init(args) => skills_init(args),
+        DevSkillsCommand::Status => skills_status(),
+    }
+}
+
+fn generate_age_key(overwrite: bool) -> Result<()> {
+    require_tool("age-keygen", "install age via your package manager or mise")?;
+    let key_path = age_key_path()?;
+    if key_path.exists() && !overwrite {
+        bail!(
+            "age key already exists at {}. rerun with --overwrite after reviewing the risk",
+            key_path.display()
+        );
+    }
+    if let Some(parent) = key_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let key_arg = key_path
+        .to_str()
+        .with_context(|| format!("path is not valid UTF-8: {}", key_path.display()))?;
+    let output = run_capture("age-keygen", &["-o", key_arg], None)?;
+    if !output.success {
+        bail!("age-keygen failed: {}", output.error);
+    }
+    println!("Generated age key: {}", key_path.display());
+    show_age_key()
+}
+
+fn show_age_key() -> Result<()> {
+    let key_path = age_key_path()?;
+    let content = read(&key_path).with_context(|| {
+        format!(
+            "age key not found at {}. generate one with `cargo run -p repo-tools -- dev age-key generate`",
+            key_path.display()
+        )
+    })?;
+    let public_key = content
+        .lines()
+        .find_map(|line| line.strip_prefix("# public key: "))
+        .context("age key file is missing the public key comment")?;
+    println!("Age public key:");
+    println!("{public_key}");
+    println!();
+    println!("Key file: {}", key_path.display());
+    Ok(())
+}
+
+fn age_key_path() -> Result<std::path::PathBuf> {
+    Ok(user_home_dir()?.join(AGE_KEY_RELATIVE_PATH))
+}
+
+fn process_status() -> Result<()> {
+    let root = workspace_root()?;
+    println!("=== Project process status ===");
+    print_port_process(&root, 3010, "web-bff")?;
+    for worker in WORKERS {
+        print_port_process(&root, worker.port, worker.package)?;
+    }
+    Ok(())
+}
+
+fn process_ports() -> Result<()> {
+    let root = workspace_root()?;
+    println!("=== Project port occupancy ===");
+    print_port_process(&root, 3010, "web-bff")?;
+    for worker in WORKERS {
+        print_port_process(&root, worker.port, worker.package)?;
+    }
+    Ok(())
+}
+
+fn stop_default_processes() -> Result<()> {
+    println!("Stopping default development processes...");
+    for pattern in DEFAULT_STOP_PATTERNS {
+        stop_processes_matching(pattern)?;
+    }
+    println!("Done.");
+    Ok(())
+}
+
+fn print_port_process(root: &std::path::Path, port: u16, label: &str) -> Result<()> {
+    #[cfg(windows)]
+    {
+        return print_port_process_windows(port, label);
+    }
+    #[cfg(not(windows))]
+    {
+        print_port_process_unix(root, port, label)
+    }
+}
+
+#[cfg(not(windows))]
+fn print_port_process_unix(root: &std::path::Path, port: u16, label: &str) -> Result<()> {
+    println!("Port {port} ({label}):");
+    let port_string = format!(":{port}");
+    let output = run_capture("lsof", &["-i", &port_string], Some(root))?;
+    if !output.success || output.output.trim().is_empty() {
+        println!("  [FREE]");
+        return Ok(());
+    }
+    for line in output.output.lines() {
+        println!("  {line}");
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn print_port_process_windows(port: u16, label: &str) -> Result<()> {
+    println!("Port {port} ({label}):");
+    let lines = windows_port_lines(port)?;
+    if lines.is_empty() {
+        println!("  [FREE]");
+        return Ok(());
+    }
+    for line in lines {
+        println!("  {line}");
+    }
+    Ok(())
+}
+
+fn stop_port(args: DevStopPortArgs) -> Result<()> {
+    #[cfg(windows)]
+    {
+        return stop_port_windows(args.port);
+    }
+    #[cfg(not(windows))]
+    {
+        stop_port_unix(args)
+    }
+}
+
+#[cfg(not(windows))]
+fn stop_port_unix(args: DevStopPortArgs) -> Result<()> {
+    let root = workspace_root()?;
+    let port_string = format!(":{}", args.port);
+    let lsof = run_capture("lsof", &["-ti", &port_string], Some(&root))?;
+    if !lsof.success || lsof.output.trim().is_empty() {
+        println!("Nothing is listening on port {}", args.port);
+        return Ok(());
+    }
+
+    for pid in lsof
+        .output
+        .lines()
+        .map(str::trim)
+        .filter(|pid| !pid.is_empty())
+    {
+        let status = run_capture("kill", &["-TERM", pid], Some(&root))?;
+        if !status.success {
+            bail!(
+                "failed to stop pid {pid} on port {}: {}",
+                args.port,
+                status.error
+            );
+        }
+        println!("Stopped pid {pid} on port {}", args.port);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn stop_port_windows(port: u16) -> Result<()> {
+    let pids = windows_port_pids(port)?;
+    if pids.is_empty() {
+        println!("Nothing is listening on port {port}");
+        return Ok(());
+    }
+
+    for pid in pids {
+        terminate_pid(pid)?;
+        println!("Stopped pid {pid} on port {port}");
+    }
+    Ok(())
+}
+
+fn clean_orphans() -> Result<()> {
+    #[cfg(windows)]
+    {
+        clean_orphans_windows()
+    }
+    #[cfg(not(windows))]
+    {
+        clean_orphans_unix()
+    }
+}
+
+#[cfg(windows)]
+fn clean_orphans_windows() -> Result<()> {
+    println!("Cleaning non-responding user processes on Windows...");
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "Get-Process | Where-Object { $_.Responding -eq $false -and $_.SessionId -eq (Get-Process -Id $PID).SessionId } | Select-Object -ExpandProperty Id",
+        ])
+        .output()
+        .context("failed to inspect Windows processes")?;
+    if !output.status.success() {
+        bail!("failed to inspect Windows processes");
+    }
+
+    let pids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|pid| !pid.is_empty())
+        .collect::<Vec<_>>();
+    if pids.is_empty() {
+        println!("No non-responding processes found.");
+        return Ok(());
+    }
+
+    for pid in pids {
+        let status = Command::new("taskkill")
+            .args(["/PID", pid, "/F"])
+            .status()
+            .with_context(|| format!("failed to stop pid {pid}"))?;
+        if !status.success() {
+            bail!("failed to stop pid {pid}");
+        }
+        println!("Stopped pid {pid}");
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn clean_orphans_unix() -> Result<()> {
+    require_tool("ps", "install procps or use a Unix-like shell")?;
+    println!("Cleaning orphaned zombie processes for the current user...");
+    let zombies = Command::new("ps")
+        .args(["-axo", "pid=,stat="])
+        .output()
+        .context("failed to inspect process table")?;
+    if !zombies.status.success() {
+        bail!("failed to inspect process table");
+    }
+
+    let pids = String::from_utf8_lossy(&zombies.stdout)
+        .lines()
+        .filter_map(parse_zombie_pid)
+        .collect::<Vec<_>>();
+    if pids.is_empty() {
+        println!("No zombie processes found.");
+        return Ok(());
+    }
+
+    for pid in pids {
+        let pid_text = pid.to_string();
+        let status = run_capture("kill", &["-9", &pid_text], None)?;
+        if !status.success {
+            if status.error.contains("No such process") {
+                println!("Skipped zombie pid {pid} (already exited)");
+                continue;
+            }
+            bail!("failed to clean zombie pid {pid}: {}", status.error);
+        }
+        println!("Cleaned zombie pid {pid}");
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn parse_zombie_pid(line: &str) -> Option<u32> {
+    let mut parts = line.split_whitespace();
+    let pid = parts.next()?.parse::<u32>().ok()?;
+    let stat = parts.next()?;
+    stat.starts_with('Z').then_some(pid)
+}
+
+fn create_migration(args: DevCreateMigrationArgs) -> Result<()> {
+    let operation = Operation::new("dev-migration-create", true);
+    operation.phase(
+        OperationPhase::Plan,
+        format!("prepare migration file for {}", args.name),
+    );
+    let root = workspace_root()?;
+    let dir = root.join("ops/migrations/api");
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    let timestamp = run_capture("date", &["+%Y%m%d%H%M%S"], Some(&root))?;
+    if !timestamp.success || timestamp.output.trim().is_empty() {
+        bail!("failed to generate migration timestamp");
+    }
+    let file = dir.join(format!(
+        "{}_{}.sql",
+        timestamp.output.trim(),
+        sanitize_migration_name(&args.name)
+    ));
+    if file.exists() {
+        bail!("migration already exists: {}", file.display());
+    }
+    operation.phase(
+        OperationPhase::Execute,
+        format!("create {}", normalize_slashes(file.strip_prefix(&root)?)),
+    );
+    write(&file, "")?;
+    println!(
+        "Created migration: {}",
+        normalize_slashes(file.strip_prefix(&root)?)
+    );
+    Ok(())
+}
+
+fn sanitize_migration_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| match ch {
+            'a'..='z' | '0'..='9' => ch,
+            'A'..='Z' => ch.to_ascii_lowercase(),
+            _ => '_',
+        })
+        .collect()
+}
+
+fn start_workers(args: DevWorkerStartArgs) -> Result<()> {
+    let root = workspace_root()?;
+    let state_dir = worker_state_dir(&root);
+    fs::create_dir_all(&state_dir)
+        .with_context(|| format!("failed to create {}", state_dir.display()))?;
+    println!("Starting workers...");
+    for worker in WORKERS {
+        println!("  - {} (health: :{})", worker.binary(), worker.port);
+    }
+    println!();
+
+    if args.attach {
+        println!(
+            "Attach mode only supports a single worker. Use `repo-tools dev worker run <name>`."
+        );
+        bail!("--attach is not supported for the full worker set");
+    }
+
+    for worker in WORKERS {
+        stop_worker(&state_dir, *worker)?;
+        spawn_background_worker(&root, &state_dir, *worker)?;
+    }
+
+    println!("All workers started in background.");
+    println!("Use `cargo run -p repo-tools -- dev worker stop` to stop them.");
+    Ok(())
+}
+
+fn stop_workers() -> Result<()> {
+    let root = workspace_root()?;
+    let state_dir = worker_state_dir(&root);
+    println!("Stopping workers...");
+    for worker in WORKERS {
+        stop_worker(&state_dir, *worker)?;
+    }
+    println!("Done.");
+    Ok(())
+}
+
+fn worker_status() -> Result<()> {
+    let root = workspace_root()?;
+    let state_dir = worker_state_dir(&root);
+    println!("=== Worker Runtime Status ===");
+    println!("State dir: {}", state_dir.display());
+    for worker in WORKERS {
+        let pid_path = worker_pid_path(&state_dir, *worker);
+        let log_path = worker_log_path(&state_dir, *worker);
+        let pid = read_pid(&pid_path)?;
+        let running = pid.is_some_and(process_exists);
+        println!();
+        println!("{}:", worker.binary());
+        match pid {
+            Some(pid) if running => println!("  pid: {pid} [RUNNING]"),
+            Some(pid) => println!("  pid: {pid} [STALE]"),
+            None => println!("  pid: [NONE]"),
+        }
+        println!("  log: {}", log_path.display());
+    }
+    Ok(())
+}
+
+fn run_single_worker(args: DevWorkerRunArgs) -> Result<()> {
+    let worker = worker_by_name(&args.worker)?;
+    println!("Starting {}...", worker.binary());
+    let root = workspace_root()?;
+    let code = run_inherit("cargo", &["run", "-p", worker.binary()], Some(&root))?;
+    if code != 0 {
+        bail!("{} exited with status {code}", worker.binary());
+    }
+    Ok(())
+}
+
+fn worker_health() -> Result<()> {
+    let client = Client::builder().build()?;
+    println!("=== Worker Health ===");
+    for worker in WORKERS {
+        println!();
+        println!("{} (:{}):", worker.binary(), worker.port);
+        let url = format!("http://localhost:{}/healthz", worker.port);
+        match client.get(&url).send() {
+            Ok(response) => {
+                let status = response.status();
+                let body = response.text().unwrap_or_default();
+                if status.is_success() {
+                    println!("{}", format_health_body(&body));
+                } else {
+                    println!("[HTTP {}] {}", status.as_u16(), body.trim());
+                }
+            }
+            Err(_) => println!("[UNREACHABLE]"),
+        }
+    }
+    Ok(())
+}
+
+fn skills_list() -> Result<()> {
+    println!("=== Installed AI Skills ===");
+    run_skills_cli(&["list"])?;
+    println!();
+    println!("Add more skills: just skills-add <github-repo-or-url>");
+    Ok(())
+}
+
+fn skills_find(args: DevSkillsFindArgs) -> Result<()> {
+    let query = args.query.unwrap_or_default();
+    if query.trim().is_empty() {
+        run_skills_cli(&["find"])
+    } else {
+        run_skills_cli(&["find", query.trim()])
+    }
+}
+
+fn skills_check() -> Result<()> {
+    println!("=== Checking for Skill Updates ===");
+    run_skills_cli(&["check"])
+}
+
+fn skills_add(args: DevSkillsAddArgs) -> Result<()> {
+    println!("=== Adding Skill: {} ===", args.source);
+    run_skills_cli(&["add", &args.source])
+}
+
+fn skills_add_specific(args: DevSkillsAddSpecificArgs) -> Result<()> {
+    println!(
+        "=== Adding Specific Skill: {} from {} ===",
+        args.skill, args.source
+    );
+    run_skills_cli(&["add", &args.source, "-s", &args.skill])
+}
+
+fn skills_update() -> Result<()> {
+    println!("=== Updating All Skills ===");
+    run_skills_cli(&["update"])
+}
+
+fn skills_remove(args: DevSkillsRemoveArgs) -> Result<()> {
+    println!("=== Removing Skill: {} ===", args.skill);
+    run_skills_cli(&["remove", &args.skill])
+}
+
+fn skills_init(args: DevSkillsInitArgs) -> Result<()> {
+    println!("=== Creating Skill: {} ===", args.name);
+    run_skills_cli(&["init", &args.name])?;
+    println!();
+    println!(
+        "Edit the template at: .agents/skills/{}/SKILL.md",
+        args.name
+    );
+    Ok(())
+}
+
+fn skills_status() -> Result<()> {
+    println!("=== Skills Directory Structure ===");
+    println!();
+    run_skills_cli(&["list"])
+}
+
+fn run_skills_cli(args: &[&str]) -> Result<()> {
+    require_tool(SKILLS_RUNNER, "install Bun or add bunx to PATH")?;
+    let root = workspace_root()?;
+    let mut full_args = vec![SKILLS_CLI];
+    full_args.extend_from_slice(args);
+    let code = run_inherit(SKILLS_RUNNER, &full_args, Some(&root))?;
+    if code != 0 {
+        bail!("bunx skills failed with status {code}");
+    }
+    Ok(())
+}
+
+fn stop_processes_matching(pattern: &str) -> Result<()> {
+    #[cfg(windows)]
+    {
+        return stop_processes_matching_windows(pattern);
+    }
+    #[cfg(not(windows))]
+    {
+        stop_processes_matching_unix(pattern)
+    }
+}
+
+#[cfg(not(windows))]
+fn stop_processes_matching_unix(pattern: &str) -> Result<()> {
+    let output = run_capture("pkill", &["-f", pattern], None)?;
+    if output.success {
+        println!("  stopped pattern: {pattern}");
+        return Ok(());
+    }
+    let stderr = output.error.trim();
+    if stderr.is_empty() {
+        println!("  pattern not running: {pattern}");
+        return Ok(());
+    }
+    bail!("failed to stop pattern `{pattern}`: {stderr}")
+}
+
+#[cfg(windows)]
+fn stop_processes_matching_windows(pattern: &str) -> Result<()> {
+    let script = format!(
+        "Get-CimInstance Win32_Process | Where-Object {{ $_.CommandLine -like '*{pattern}*' }} | Select-Object -ExpandProperty ProcessId"
+    );
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .context("failed to inspect Windows processes")?;
+    if !output.status.success() {
+        bail!("failed to inspect Windows processes for pattern `{pattern}`");
+    }
+
+    let pids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .collect::<Vec<_>>();
+    if pids.is_empty() {
+        println!("  pattern not running: {pattern}");
+        return Ok(());
+    }
+
+    for pid in pids {
+        terminate_pid(pid)?;
+    }
+    println!("  stopped pattern: {pattern}");
+    Ok(())
+}
+
+fn spawn_background_worker(root: &Path, state_dir: &Path, worker: WorkerSpec) -> Result<()> {
+    let log_path = worker_log_path(state_dir, worker);
+    let pid_path = worker_pid_path(state_dir, worker);
+    let stdout = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("failed to open {}", log_path.display()))?;
+    let stderr = stdout
+        .try_clone()
+        .with_context(|| format!("failed to clone {}", log_path.display()))?;
+
+    let child = Command::new("cargo")
+        .args(["run", "-p", worker.binary()])
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .with_context(|| format!("failed to start {}", worker.binary()))?;
+
+    write(&pid_path, &child.id().to_string())?;
+    println!(
+        "  started {} pid={} log={}",
+        worker.binary(),
+        child.id(),
+        log_path.display()
+    );
+    Ok(())
+}
+
+fn stop_worker(state_dir: &Path, worker: WorkerSpec) -> Result<()> {
+    let pid_path = worker_pid_path(state_dir, worker);
+    if let Some(pid) = read_pid(&pid_path)? {
+        if process_exists(pid) {
+            terminate_pid(pid)?;
+            println!("  stopped {} pid={}", worker.binary(), pid);
+        } else {
+            println!("  stale pid removed for {} ({})", worker.binary(), pid);
+        }
+        remove_if_exists(&pid_path)?;
+        return Ok(());
+    }
+
+    stop_processes_matching(worker.binary())
+}
+
+fn worker_state_dir(root: &Path) -> PathBuf {
+    root.join(WORKER_STATE_DIR)
+}
+
+fn worker_pid_path(state_dir: &Path, worker: WorkerSpec) -> PathBuf {
+    state_dir.join(format!("{}.pid", worker.binary()))
+}
+
+fn worker_log_path(state_dir: &Path, worker: WorkerSpec) -> PathBuf {
+    state_dir.join(format!("{}.log", worker.binary()))
+}
+
+fn read_pid(path: &Path) -> Result<Option<u32>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = read(path)?;
+    let pid = content
+        .trim()
+        .parse::<u32>()
+        .with_context(|| format!("invalid pid file {}", path.display()))?;
+    Ok(Some(pid))
+}
+
+fn process_exists(pid: u32) -> bool {
+    #[cfg(windows)]
+    {
+        process_exists_windows(pid)
+    }
+    #[cfg(not(windows))]
+    {
+        process_exists_unix(pid)
+    }
+}
+
+#[cfg(not(windows))]
+fn process_exists_unix(pid: u32) -> bool {
+    run_capture("kill", &["-0", &pid.to_string()], None)
+        .map(|outcome| outcome.success)
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn process_exists_windows(pid: u32) -> bool {
+    Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}")])
+        .output()
+        .map(|output| {
+            output.status.success()
+                && String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .any(|line| line.contains(&pid.to_string()))
+        })
+        .unwrap_or(false)
+}
+
+fn terminate_pid(pid: u32) -> Result<()> {
+    #[cfg(windows)]
+    {
+        let status = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .status()
+            .with_context(|| format!("failed to stop pid {pid}"))?;
+        if !status.success() {
+            bail!("failed to stop pid {pid}");
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        let status = run_capture("kill", &["-TERM", &pid.to_string()], None)?;
+        if !status.success {
+            bail!("failed to stop pid {pid}: {}", status.error);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn windows_port_lines(port: u16) -> Result<Vec<String>> {
+    let output = Command::new("netstat")
+        .args(["-ano", "-p", "tcp"])
+        .output()
+        .context("failed to inspect Windows TCP ports")?;
+    if !output.status.success() {
+        bail!("failed to inspect Windows TCP ports");
+    }
+    let needle = format!(":{port}");
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("TCP") && line.contains(&needle))
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+#[cfg(windows)]
+fn windows_port_pids(port: u16) -> Result<Vec<u32>> {
+    let mut pids = windows_port_lines(port)?
+        .into_iter()
+        .filter_map(|line| line.split_whitespace().last()?.parse::<u32>().ok())
+        .collect::<Vec<_>>();
+    pids.sort_unstable();
+    pids.dedup();
+    Ok(pids)
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn worker_by_name(name: &str) -> Result<&'static WorkerSpec> {
+    WORKERS
+        .iter()
+        .find(|worker| worker.package == name || worker.binary() == name)
+        .with_context(|| format!("unknown worker `{name}`"))
+}
+
+fn format_health_body(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "[EMPTY RESPONSE]".to_string();
+    }
+    if let Ok(json) = serde_json::from_str::<Value>(trimmed) {
+        return serde_json::to_string_pretty(&json).unwrap_or_else(|_| trimmed.to_string());
+    }
+    trimmed.to_string()
+}
+
+#[derive(Clone, Copy)]
+struct WorkerSpec {
+    package: &'static str,
+    port: u16,
+}
+
+impl WorkerSpec {
+    const fn new(package: &'static str, port: u16) -> Self {
+        Self { package, port }
+    }
+
+    fn binary(self) -> &'static str {
+        match self.package {
+            "outbox-relay" => "outbox-relay-worker",
+            "indexer" => "indexer-worker",
+            "projector" => "projector-worker",
+            "scheduler" => "scheduler-worker",
+            "sync-reconciler" => "sync-reconciler-worker",
+            _ => self.package,
+        }
+    }
+}
+
+pub(crate) fn scan_vuln(args: ScanVulnArgs) -> Result<()> {
+    require_tool("trivy", "install trivy via your package manager or mise")?;
+    let root = workspace_root()?;
+    let exit_code = args.exit_code.to_string();
+    if args.image.trim().is_empty() {
+        println!("=== Trivy filesystem scan ===");
+        let target = root.to_string_lossy().to_string();
+        let code = run_inherit(
+            "trivy",
+            &[
+                "fs",
+                "--severity",
+                "HIGH,CRITICAL",
+                "--exit-code",
+                &exit_code,
+                &target,
+            ],
+            Some(&root),
+        )?;
+        if code != 0 {
+            bail!("trivy fs failed with status {code}");
+        }
+        return Ok(());
+    }
+
+    println!("=== Trivy image scan: {} ===", args.image);
+    let code = run_inherit(
+        "trivy",
+        &[
+            "image",
+            "--severity",
+            "HIGH,CRITICAL",
+            "--exit-code",
+            &exit_code,
+            &args.image,
+        ],
+        Some(&root),
+    )?;
+    if code != 0 {
+        bail!("trivy image failed with status {code}");
+    }
+    Ok(())
+}
+
+pub(crate) fn gen_sbom(args: GenSbomArgs) -> Result<()> {
+    require_tool("syft", "install syft via your package manager or mise")?;
+    let root = workspace_root()?;
+    let target = if args.image.trim().is_empty() {
+        println!("=== Syft SBOM: workspace ===");
+        format!("dir:{}", root.display())
+    } else {
+        println!("=== Syft SBOM: image {} ===", args.image);
+        args.image.clone()
+    };
+    let output_format = if args.output == "-" {
+        args.format.clone()
+    } else {
+        format!("{}={}", args.format, args.output)
+    };
+    let code = run_inherit("syft", &[&target, "-o", &output_format], Some(&root))?;
+    if code != 0 {
+        bail!("syft failed with status {code}");
+    }
+    Ok(())
+}
+
+pub(crate) fn sign_image(args: ImageRefArgs) -> Result<()> {
+    require_tool("cosign", "install cosign via your package manager or mise")?;
+    println!("=== Cosign sign: {} ===", args.image);
+    let code = run_inherit("cosign", &["sign", &args.image], None)?;
+    if code != 0 {
+        bail!("cosign sign failed with status {code}");
+    }
+    Ok(())
+}
+
+pub(crate) fn verify_image(args: ImageRefArgs) -> Result<()> {
+    require_tool("cosign", "install cosign via your package manager or mise")?;
+    println!("=== Cosign verify: {} ===", args.image);
+    let code = run_inherit("cosign", &["verify", &args.image], None)?;
+    if code != 0 {
+        bail!("cosign verify failed with status {code}");
+    }
+    Ok(())
+}
 
 pub(crate) fn generate_service(args: GenerateServiceArgs) -> Result<()> {
     let working_directory = workspace_root()?;

--- a/tools/repo-tools/src/commands/doctor.rs
+++ b/tools/repo-tools/src/commands/doctor.rs
@@ -32,3 +32,15 @@ pub(crate) fn doctor() -> Result<()> {
     println!("\n=== Done ===");
     Ok(())
 }
+
+pub(crate) fn toolchain_check() -> Result<()> {
+    for tool in ["rustc", "moon"] {
+        if !has_tool(tool) {
+            anyhow::bail!("{tool} not in PATH");
+        }
+        let result = run_capture(tool, &["--version"], None)?;
+        println!("{}", result.output);
+    }
+    println!("ALL OK");
+    Ok(())
+}

--- a/tools/repo-tools/src/commands/harness.rs
+++ b/tools/repo-tools/src/commands/harness.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result, bail};
 
 use crate::cli::{GateArgs, GateGuidanceArgs, GateName, RouteTaskArgs, VerifyHandoffArgs};
+use crate::core::manifest::{load_codemap, load_gate_matrix, load_routing_rules};
 use crate::support::{
     Issue, Mode, Report, collect_files_named, except_path, git_changed_paths, normalize_slashes,
     pattern_matches, read, run_capture, same_module, workspace_root,
@@ -16,14 +17,18 @@ struct GateCommand {
 }
 
 pub(crate) fn gate_guidance(args: GateGuidanceArgs) -> Result<()> {
-    let legacy_agents = [
-        "contract-agent",
-        "app-shell-agent",
-        "server-agent",
-        "service-agent",
-        "worker-agent",
-        "platform-ops-agent",
-    ];
+    let root = workspace_root()?;
+    let routing = load_routing_rules(&root)?;
+    let gate_matrix = load_gate_matrix(&root)?;
+    let mut legacy_agents = routing
+        .rules
+        .iter()
+        .map(|rule| rule.primary.as_str())
+        .filter(|agent| *agent != "planner")
+        .collect::<Vec<_>>();
+    legacy_agents.sort();
+    legacy_agents.dedup();
+
     if args.list {
         println!("\n=== Gate Selection ===\n");
         println!("Gate selection is path/risk/evidence based, not subagent based.");
@@ -33,8 +38,12 @@ pub(crate) fn gate_guidance(args: GateGuidanceArgs) -> Result<()> {
         println!("Default backend-core guardrail: just check-backend-primary");
         println!("Broader repo-wide guardrail when needed: just verify");
         println!("Release/P0 invariant gate only when justified: just gate-release");
+        println!(
+            "Loaded {} path rule(s) from agent/manifests/gate-matrix.yml.",
+            gate_matrix.path_rules.len()
+        );
         println!("\nAccepted agent scopes for this helper:");
-        for agent in legacy_agents {
+        for agent in &legacy_agents {
             println!("  - {agent}");
         }
         return Ok(());
@@ -50,45 +59,44 @@ pub(crate) fn gate_guidance(args: GateGuidanceArgs) -> Result<()> {
     println!(
         "Select gates from changed paths, risk, and evidence level in agent/manifests/gate-matrix.yml."
     );
+    let agent_patterns = routing
+        .rules
+        .iter()
+        .filter(|rule| rule.primary == agent)
+        .map(|rule| rule.r#match.as_str())
+        .collect::<Vec<_>>();
+    let path_rule_count = gate_matrix
+        .path_rules
+        .iter()
+        .filter(|rule| {
+            rule.r#match.iter().any(|pattern| {
+                agent_patterns.iter().any(|agent_pattern| {
+                    pattern_matches(pattern, agent_pattern)
+                        || pattern_matches(agent_pattern, pattern)
+                })
+            })
+        })
+        .count();
+    println!("Relevant path rules loaded: {path_rule_count}");
     println!("This compatibility helper does not run heavy gates automatically.");
     Ok(())
 }
 
 pub(crate) fn route_task(args: RouteTaskArgs) -> Result<()> {
-    let rules = [
-        ("packages/contracts/", "contract-agent"),
-        ("platform/model/", "platform-ops-agent"),
-        ("platform/schema/", "platform-ops-agent"),
-        ("platform/generators/", "platform-ops-agent"),
-        ("platform/validators/", "platform-ops-agent"),
-        ("apps/web/", "app-shell-agent"),
-        ("apps/desktop/", "app-shell-agent"),
-        ("apps/mobile/", "app-shell-agent"),
-        ("packages/ui/", "app-shell-agent"),
-        ("servers/", "server-agent"),
-        ("services/", "service-agent"),
-        ("workers/", "worker-agent"),
-        ("infra/", "platform-ops-agent"),
-        ("ops/", "platform-ops-agent"),
-        ("verification/e2e/", "app-shell-agent"),
-        ("verification/resilience/", "worker-agent"),
-        ("verification/topology/", "platform-ops-agent"),
-        ("verification/contract/", "contract-agent"),
-    ];
-    let dispatch_order = [
-        "platform-ops-agent",
-        "contract-agent",
-        "service-agent",
-        "server-agent",
-        "worker-agent",
-        "app-shell-agent",
-    ];
+    let root = workspace_root()?;
+    let routing = load_routing_rules(&root)?;
+    let dispatch_order = routing
+        .dispatch_order
+        .iter()
+        .filter(|agent| agent.as_str() != "(verify)")
+        .cloned()
+        .collect::<Vec<_>>();
 
     if args.list {
         println!("\n=== Routing Rules ===\n");
         println!("Path Pattern -> Subagent\n");
-        for (pattern, agent) in rules {
-            println!("  {:<35} -> {agent}", pattern);
+        for rule in &routing.rules {
+            println!("  {:<35} -> {}", rule.r#match, rule.primary);
         }
         println!(
             "\nDispatch order: {} -> (verify)",
@@ -97,7 +105,6 @@ pub(crate) fn route_task(args: RouteTaskArgs) -> Result<()> {
         return Ok(());
     }
 
-    let root = workspace_root()?;
     let paths = if !args.paths.is_empty() {
         args.paths
     } else if let Some(diff_range) = args.diff {
@@ -114,11 +121,15 @@ pub(crate) fn route_task(args: RouteTaskArgs) -> Result<()> {
 
     let mut by_agent: BTreeMap<&str, Vec<String>> = BTreeMap::new();
     for path in &paths {
-        if let Some((_, agent)) = rules
+        if let Some(rule) = routing
+            .rules
             .iter()
-            .find(|(pattern, _)| path.starts_with(*pattern) || path.contains(pattern))
+            .find(|rule| pattern_matches(path, &rule.r#match))
         {
-            by_agent.entry(agent).or_default().push(path.clone());
+            by_agent
+                .entry(rule.primary.as_str())
+                .or_default()
+                .push(path.clone());
         }
     }
 
@@ -134,14 +145,28 @@ pub(crate) fn route_task(args: RouteTaskArgs) -> Result<()> {
 
     let affected: Vec<&str> = dispatch_order
         .iter()
-        .copied()
+        .map(String::as_str)
         .filter(|agent| by_agent.contains_key(agent))
         .collect();
+    let planner_paths = by_agent.get("planner").cloned().unwrap_or_default();
     let mut dispatch = affected.clone();
+    if !planner_paths.is_empty() {
+        dispatch.insert(0, "planner");
+    }
     dispatch.push("(verify)");
-    println!("Affected domains:    {}", affected.join(", "));
+    let mut affected_domains = affected.iter().copied().collect::<Vec<_>>();
+    if !planner_paths.is_empty() {
+        affected_domains.insert(0, "planner");
+    }
+    println!("Affected domains:    {}", affected_domains.join(", "));
     println!("Dispatch order:      {}", dispatch.join(" -> "));
     println!("\nPath -> Agent mapping:");
+    if !planner_paths.is_empty() {
+        println!("\n  planner:");
+        for path in &planner_paths {
+            println!("    {path}");
+        }
+    }
     for agent in affected {
         println!("\n  {agent}:");
         if let Some(agent_paths) = by_agent.get(agent) {
@@ -326,12 +351,13 @@ pub(crate) fn gate_name_label(gate: GateName) -> &'static str {
 }
 
 struct SubagentBoundary {
-    writable: &'static [&'static str],
-    readonly: &'static [&'static str],
+    writable: Vec<String>,
+    readonly: Vec<String>,
 }
 
 pub(crate) fn verify_handoff(args: VerifyHandoffArgs) -> Result<()> {
-    let boundaries = subagent_boundaries();
+    let root = workspace_root()?;
+    let boundaries = subagent_boundaries(&root)?;
     let Some(boundary) = boundaries.get(args.agent.as_str()) else {
         eprintln!("Unknown subagent: {}", args.agent);
         eprintln!("Available subagents:");
@@ -411,83 +437,19 @@ pub(crate) fn verify_handoff(args: VerifyHandoffArgs) -> Result<()> {
     Ok(())
 }
 
-fn subagent_boundaries() -> BTreeMap<&'static str, SubagentBoundary> {
-    BTreeMap::from([
-        (
-            "contract-agent",
+fn subagent_boundaries(root: &std::path::Path) -> Result<BTreeMap<String, SubagentBoundary>> {
+    let codemap = load_codemap(root)?;
+    let mut boundaries = BTreeMap::new();
+    for (agent, boundary) in codemap.write_boundaries {
+        boundaries.insert(
+            agent,
             SubagentBoundary {
-                writable: &[
-                    "packages/contracts/",
-                    "docs/contracts/",
-                    "verification/contract/",
-                ],
-                readonly: &[
-                    "packages/sdk/",
-                    "docs/generated/",
-                    "infra/kubernetes/rendered/",
-                    "platform/catalog/",
-                ],
+                writable: boundary.may_modify,
+                readonly: boundary.must_not_modify,
             },
-        ),
-        (
-            "app-shell-agent",
-            SubagentBoundary {
-                writable: &[],
-                readonly: &["services/", "workers/", "infra/", "packages/sdk/"],
-            },
-        ),
-        (
-            "server-agent",
-            SubagentBoundary {
-                writable: &["servers/", "packages/contracts/"],
-                readonly: &["services/", "infra/", "apps/", "workers/"],
-            },
-        ),
-        (
-            "service-agent",
-            SubagentBoundary {
-                writable: &[
-                    "services/",
-                    "fixtures/",
-                    "verification/",
-                    "packages/contracts/",
-                ],
-                readonly: &["infra/", "packages/", "apps/", "servers/", "workers/"],
-            },
-        ),
-        (
-            "worker-agent",
-            SubagentBoundary {
-                writable: &[
-                    "workers/",
-                    "verification/resilience/",
-                    "verification/topology/",
-                ],
-                readonly: &["apps/", "packages/sdk/", "infra/"],
-            },
-        ),
-        (
-            "platform-ops-agent",
-            SubagentBoundary {
-                writable: &[
-                    "platform/model/",
-                    "platform/schema/",
-                    "platform/generators/",
-                    "platform/validators/",
-                    "infra/",
-                    "ops/",
-                    "docs/platform-model/",
-                    "docs/operations/",
-                ],
-                readonly: &[
-                    "platform/catalog/",
-                    "infra/kubernetes/rendered/",
-                    "docs/generated/",
-                    "packages/sdk/",
-                ],
-            },
-        ),
-    ])
+        );
+    }
+    Ok(boundaries)
 }
 
 fn modified_paths() -> Result<Vec<String>> {

--- a/tools/repo-tools/src/commands/infra.rs
+++ b/tools/repo-tools/src/commands/infra.rs
@@ -9,10 +9,13 @@ use anyhow::{Context, Result, bail};
 use crate::cli::{
     ContainerRuntime, InfraArgs, InfraAuthCommand, InfraCommand, InfraK3sBootstrapArgs,
     InfraK3sCommand, InfraK3sDeployArgs, InfraLocalCommand, InfraLocalDownArgs, InfraLocalLogsArgs,
-    InfraLocalStatusArgs, InfraLocalUpArgs, KubectlDryRunMode,
+    InfraLocalStatusArgs, InfraLocalUpArgs, InfraObservabilityCommand, InfraObservabilityDownArgs,
+    InfraObservabilityLogsArgs, InfraObservabilityStatusArgs, InfraObservabilityUpArgs,
+    KubectlDryRunMode,
 };
 use crate::support::{
-    has_tool, read, require_tool, run_capture, run_inherit, wait_for_port, workspace_root, write,
+    Operation, OperationPhase, has_tool, read, require_tool, run_capture, run_inherit,
+    wait_for_port, workspace_root, write,
 };
 
 const AUTH_COMPOSE_FILE: &str = "infra/docker/compose/auth.yaml";
@@ -23,6 +26,7 @@ const AUTH_GENERATED_DIR: &str = "infra/local/generated";
 const AUTH_ENV_FILE: &str = "infra/local/generated/auth.env";
 const OPENFGA_MODEL_FILE: &str = "fixtures/authz-tuples/counter-model.openfga.json";
 const K3S_OVERLAYS_DIR: &str = "infra/k3s/overlays";
+const OBSERVABILITY_COMPOSE_FILE: &str = "infra/docker/compose/observability.yaml";
 
 pub(crate) fn run(args: InfraArgs) -> Result<()> {
     match args.command {
@@ -42,6 +46,7 @@ fn run_local(command: InfraLocalCommand) -> Result<()> {
         InfraLocalCommand::Down(args) => local_down(&root, args),
         InfraLocalCommand::Status(args) => local_status(&root, args),
         InfraLocalCommand::Logs(args) => local_logs(&root, args),
+        InfraLocalCommand::Observability(args) => run_observability(&root, args.command),
     }
 }
 
@@ -102,6 +107,59 @@ fn local_logs(root: &Path, args: InfraLocalLogsArgs) -> Result<()> {
     run_local_compose(root, runtime, compose_args)
 }
 
+fn run_observability(root: &Path, command: InfraObservabilityCommand) -> Result<()> {
+    match command {
+        InfraObservabilityCommand::Up(args) => observability_up(root, args),
+        InfraObservabilityCommand::Down(args) => observability_down(root, args),
+        InfraObservabilityCommand::Status(args) => observability_status(root, args),
+        InfraObservabilityCommand::Logs(args) => observability_logs(root, args),
+    }
+}
+
+fn observability_up(root: &Path, args: InfraObservabilityUpArgs) -> Result<()> {
+    let runtime = resolve_runtime(args.runtime)?;
+    let mut subcommand = vec!["up"];
+    if args.detach {
+        subcommand.push("-d");
+    }
+    println!("Starting observability stack with {}", runtime.label());
+    run_observability_compose(root, runtime, &subcommand)?;
+    print_observability_connection_info();
+    Ok(())
+}
+
+fn observability_down(root: &Path, args: InfraObservabilityDownArgs) -> Result<()> {
+    let runtime = resolve_runtime(args.runtime)?;
+    println!("Stopping observability stack with {}", runtime.label());
+    run_observability_compose(root, runtime, &["down"])
+}
+
+fn observability_status(root: &Path, args: InfraObservabilityStatusArgs) -> Result<()> {
+    let runtime = resolve_runtime(args.runtime)?;
+    let mut subcommand = vec!["ps"];
+    if args.json {
+        subcommand.push("--format");
+        subcommand.push("json");
+    }
+    run_observability_compose(root, runtime, &subcommand)?;
+    if !args.json {
+        print_observability_connection_info();
+    }
+    Ok(())
+}
+
+fn observability_logs(root: &Path, args: InfraObservabilityLogsArgs) -> Result<()> {
+    let runtime = resolve_runtime(args.runtime)?;
+    let mut subcommand = vec!["logs"];
+    if args.follow {
+        subcommand.push("-f");
+    }
+    if let Some(service) = args.service.as_deref() {
+        subcommand.push(service);
+    }
+    run_observability_compose(root, runtime, &subcommand)
+}
+
 fn resolve_runtime(requested: Option<ContainerRuntime>) -> Result<ContainerRuntime> {
     if let Some(runtime) = requested {
         require_tool(runtime.binary(), &format!("install {}", runtime.label()))?;
@@ -150,6 +208,28 @@ fn run_local_compose(root: &Path, runtime: ContainerRuntime, args: Vec<String>) 
     Ok(())
 }
 
+fn run_observability_compose(
+    root: &Path,
+    runtime: ContainerRuntime,
+    subcommand: &[&str],
+) -> Result<()> {
+    let compose_file = root.join(OBSERVABILITY_COMPOSE_FILE);
+    if !compose_file.is_file() {
+        bail!(
+            "observability compose file not found: {}",
+            compose_file.display()
+        );
+    }
+
+    let mut args = vec!["compose", "-f", OBSERVABILITY_COMPOSE_FILE];
+    args.extend_from_slice(subcommand);
+    let code = run_inherit(runtime.binary(), &args, Some(root))?;
+    if code != 0 {
+        bail!("{} failed with status {code}", runtime.label());
+    }
+    Ok(())
+}
+
 fn print_local_connection_info() {
     println!();
     println!("Local infrastructure endpoints:");
@@ -160,6 +240,12 @@ fn print_local_connection_info() {
     println!("  Valkey: redis://localhost:6379");
     println!("  MinIO API: http://localhost:9000");
     println!("  MinIO Console: http://localhost:9001 (minioadmin/minioadmin)");
+}
+
+fn print_observability_connection_info() {
+    println!();
+    println!("Observability endpoints:");
+    println!("  OpenObserve UI: http://localhost:5080 (admin@localhost / admin)");
 }
 
 fn run_auth(command: InfraAuthCommand) -> Result<()> {
@@ -476,9 +562,15 @@ fn unix_timestamp() -> Result<u64> {
 }
 
 fn k3s_deploy(args: InfraK3sDeployArgs) -> Result<()> {
+    let operation = Operation::new("infra-k3s-deploy", args.dry_run.is_none());
     let root = workspace_root()?;
     let overlay = k3s_overlay(&root, &args.env)?;
+    operation.phase(
+        OperationPhase::Plan,
+        format!("deploy overlay {}", overlay.display()),
+    );
     preflight_k3s_deploy(&overlay, args.dry_run)?;
+    operation.phase(OperationPhase::Preflight, "k3s deploy preflight passed");
 
     println!("Deploying to k3s environment: {}", args.env);
     let render = run_capture(
@@ -512,9 +604,14 @@ fn k3s_deploy(args: InfraK3sDeployArgs) -> Result<()> {
             return Ok(());
         }
     }
+    operation.phase(
+        OperationPhase::Execute,
+        "apply rendered manifest via kubectl",
+    );
     kubectl_apply_manifest(&render.output, &apply_args, Some(&root))?;
 
     if args.dry_run.is_none() && !args.skip_verify {
+        operation.phase(OperationPhase::Verify, "wait for deployment availability");
         verify_k3s_deploy()?;
     } else if args.dry_run.is_some() {
         println!("Dry run complete; skipping post-deploy verification");
@@ -629,12 +726,18 @@ fn overlay_str(path: &Path) -> Result<&str> {
 }
 
 fn k3s_bootstrap(args: InfraK3sBootstrapArgs) -> Result<()> {
+    let operation = Operation::new(
+        "infra-k3s-bootstrap",
+        args.apply && args.i_understand_this_modifies_host,
+    );
     println!("k3s bootstrap plan:");
     println!("1. verify OS, architecture, memory, ports, and privilege state");
     println!("2. install k3s server with host-level system changes");
     println!("3. configure kubectl from /etc/rancher/k3s/k3s.yaml");
     println!("4. verify cluster health");
+    operation.phase(OperationPhase::Plan, "host mutation path is guarded");
     k3s_bootstrap_preflight()?;
+    operation.phase(OperationPhase::Preflight, "bootstrap preflight passed");
 
     if !(args.apply && args.i_understand_this_modifies_host) {
         println!("Preflight complete; not modifying host.");
@@ -642,6 +745,10 @@ fn k3s_bootstrap(args: InfraK3sBootstrapArgs) -> Result<()> {
         return Ok(());
     }
 
+    operation.phase(
+        OperationPhase::Execute,
+        "host mutation intentionally blocked",
+    );
     bail!(
         "k3s bootstrap execution is intentionally not implemented yet; the safe Phase 6 boundary is plan/preflight only"
     )

--- a/tools/repo-tools/src/commands/ops.rs
+++ b/tools/repo-tools/src/commands/ops.rs
@@ -3,8 +3,14 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
-use crate::cli::{OpsArgs, OpsBootstrapVpsArgs, OpsCommand, OpsMigrateArgs, OpsMigrationDirection};
-use crate::support::{has_tool, normalize_slashes, read, run_capture, workspace_root};
+use crate::cli::{
+    OpsArgs, OpsBootstrapVpsArgs, OpsCommand, OpsMigrateArgs, OpsMigrationDirection,
+    OpsServiceArgs, OpsServiceCommand, OpsServiceLogsArgs, OpsServiceNameArgs,
+};
+use crate::support::{
+    Operation, OperationPhase, has_tool, normalize_slashes, read, run_capture, run_inherit,
+    workspace_root,
+};
 
 const MIGRATION_SERVICES: &[&str] = &[
     "user-service",
@@ -32,6 +38,15 @@ pub(crate) fn run(args: OpsArgs) -> Result<()> {
     match args.command {
         OpsCommand::Migrate(args) => migrate(args),
         OpsCommand::BootstrapVps(args) => bootstrap_vps(args),
+        OpsCommand::Service(args) => service(args),
+    }
+}
+
+fn service(args: OpsServiceArgs) -> Result<()> {
+    match args.command {
+        OpsServiceCommand::Deploy(args) => deploy_service(args),
+        OpsServiceCommand::Stop(args) => stop_service(args),
+        OpsServiceCommand::Logs(args) => service_logs(args),
     }
 }
 
@@ -40,18 +55,30 @@ fn migrate(args: OpsMigrateArgs) -> Result<()> {
         bail!("choose either --dry-run or --apply, not both");
     }
 
+    let operation = Operation::new("ops-migrate", args.apply);
+
     let root = workspace_root()?;
     let plan = migration_plan(&root)?;
+    operation.phase(
+        OperationPhase::Plan,
+        format!(
+            "{} migration(s) discovered",
+            plan.iter()
+                .map(|service| service.migrations.len())
+                .sum::<usize>()
+        ),
+    );
 
     println!("Migration environment: {}", args.env);
     println!("Migration direction: {:?}", args.direction);
     println!("Mode: {}", if args.apply { "apply" } else { "dry-run" });
     println!("Database target: {}", database_target(&args.env)?);
     println!();
+    operation.phase(OperationPhase::Preflight, "migration arguments validated");
 
     match args.direction {
         OpsMigrationDirection::Status => print_migration_status(&root, &plan),
-        OpsMigrationDirection::Up => migrate_up(&root, &plan, args.apply),
+        OpsMigrationDirection::Up => migrate_up(&root, &plan, &operation),
         OpsMigrationDirection::Down => {
             println!(
                 "Rollback is not implemented; create a forward migration that reverses the change."
@@ -117,15 +144,19 @@ fn print_migration_status(root: &Path, plan: &[ServiceMigrations]) -> Result<()>
     Ok(())
 }
 
-fn migrate_up(root: &Path, plan: &[ServiceMigrations], apply: bool) -> Result<()> {
+fn migrate_up(root: &Path, plan: &[ServiceMigrations], operation: &Operation) -> Result<()> {
     print_migration_status(root, plan)?;
-    if !apply {
+    if !operation.is_apply() {
         println!();
         println!("Dry run complete; no migration SQL was executed.");
         println!("Use --apply to run the Phase 7 sqlite3 syntax smoke for listed SQL files.");
         return Ok(());
     }
 
+    operation.phase(
+        OperationPhase::Execute,
+        "run sqlite3 migration smoke checks",
+    );
     if !has_tool("sqlite3") {
         bail!(
             "sqlite3 is required for Phase 7 migration apply smoke; install sqlite3 or run without --apply"
@@ -154,6 +185,10 @@ fn migrate_up(root: &Path, plan: &[ServiceMigrations], apply: bool) -> Result<()
             }
         }
     }
+    operation.phase(
+        OperationPhase::Verify,
+        "all listed migration SQL parsed by sqlite3",
+    );
     println!("Migration apply smoke complete.");
     Ok(())
 }
@@ -172,13 +207,20 @@ fn bootstrap_vps(args: OpsBootstrapVpsArgs) -> Result<()> {
         bail!("choose either --plan or --apply, not both");
     }
 
+    let operation = Operation::new("ops-bootstrap-vps", args.apply);
+
     println!("VPS bootstrap plan:");
     println!("1. detect OS and package manager");
     println!("2. verify root privileges for host-level package installation");
     println!("3. install or verify git, just, mise, podman, kubectl, kustomize, age, and sops");
     println!("4. print post-install verification and next deploy steps");
     println!();
+    operation.phase(
+        OperationPhase::Plan,
+        "bootstrap remains gated behind plan/apply",
+    );
     vps_preflight()?;
+    operation.phase(OperationPhase::Preflight, "tool and host preflight printed");
 
     if !args.apply {
         println!("Plan complete; not modifying host.");
@@ -193,9 +235,55 @@ fn bootstrap_vps(args: OpsBootstrapVpsArgs) -> Result<()> {
     if confirm.trim().is_empty() {
         bail!("--confirm must name the target host");
     }
+    operation.phase(
+        OperationPhase::Execute,
+        "host mutation intentionally blocked",
+    );
     bail!(
         "VPS bootstrap apply is intentionally not implemented in Phase 7; no host changes were made"
     )
+}
+
+fn deploy_service(args: OpsServiceNameArgs) -> Result<()> {
+    let operation = Operation::new("ops-service-deploy", true);
+    operation.phase(
+        OperationPhase::Plan,
+        format!("deploy systemd service {}", args.service),
+    );
+    require_systemctl()?;
+    operation.phase(OperationPhase::Preflight, "systemctl is available");
+    let unit = service_unit(&args.service);
+
+    print_systemctl_status(&unit)?;
+    run_systemctl(&["daemon-reload"])?;
+    run_systemctl(&["enable", &unit])?;
+    operation.phase(OperationPhase::Execute, format!("restart {unit}"));
+    run_systemctl(&["restart", &unit])?;
+    operation.phase(OperationPhase::Verify, format!("status {unit}"));
+    run_systemctl(&["status", &args.service, "--no-pager"])
+}
+
+fn stop_service(args: OpsServiceNameArgs) -> Result<()> {
+    require_systemctl()?;
+    let unit = service_unit(&args.service);
+    run_systemctl(&["stop", &unit])?;
+    println!("{} stopped", unit);
+    Ok(())
+}
+
+fn service_logs(args: OpsServiceLogsArgs) -> Result<()> {
+    require_journalctl()?;
+    let unit = service_unit(&args.service);
+    let mut journal_args = vec!["journalctl", "-u", unit.as_str()];
+    if args.follow {
+        journal_args.push("-f");
+    }
+    journal_args.push("--no-pager");
+    let code = run_inherit("sudo", &journal_args, None)?;
+    if code != 0 {
+        bail!("journalctl failed with status {code}");
+    }
+    Ok(())
 }
 
 fn vps_preflight() -> Result<()> {
@@ -215,6 +303,54 @@ fn vps_preflight() -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn require_systemctl() -> Result<()> {
+    if !has_tool("systemctl") {
+        bail!("systemctl is required for host service management");
+    }
+    if !has_tool("sudo") {
+        bail!("sudo is required for host service management");
+    }
+    Ok(())
+}
+
+fn require_journalctl() -> Result<()> {
+    if !has_tool("journalctl") {
+        bail!("journalctl is required for host log access");
+    }
+    if !has_tool("sudo") {
+        bail!("sudo is required for host log access");
+    }
+    Ok(())
+}
+
+fn run_systemctl(args: &[&str]) -> Result<()> {
+    let mut full_args = vec!["systemctl"];
+    full_args.extend_from_slice(args);
+    let code = run_inherit("sudo", &full_args, None)?;
+    if code != 0 {
+        bail!("systemctl failed with status {code}");
+    }
+    Ok(())
+}
+
+fn print_systemctl_status(unit: &str) -> Result<()> {
+    let code = run_inherit("systemctl", &["is-active", "--quiet", unit], None)?;
+    if code == 0 {
+        println!("{} is running", unit);
+    } else {
+        println!("{} will be started", unit);
+    }
+    Ok(())
+}
+
+fn service_unit(name: &str) -> String {
+    if name.ends_with(".service") {
+        name.to_string()
+    } else {
+        format!("{name}.service")
+    }
 }
 
 fn detected_os() -> String {

--- a/tools/repo-tools/src/commands/platform.rs
+++ b/tools/repo-tools/src/commands/platform.rs
@@ -7,8 +7,9 @@ use regex::Regex;
 
 use crate::commands::secrets;
 use crate::support::{
-    Issue, Mode, Report, collect_files_with_extension, copy_dir_contents, list_directories,
-    normalize_slashes, read, run_capture, run_inherit, tempdir, workspace_root, write,
+    Issue, Mode, Operation, OperationPhase, Report, collect_files_with_extension,
+    copy_dir_contents, list_directories, normalize_slashes, read, run_capture, run_inherit,
+    tempdir, workspace_root, write,
 };
 
 const DIRECTORY_CATEGORY_PATTERNS: &[(&str, &str)] = &[
@@ -405,7 +406,12 @@ pub(crate) fn validate_workflows(mode: Mode) -> Result<()> {
     Ok(())
 }
 pub(crate) fn verify_counter_delivery(mode: Mode) -> Result<()> {
+    let operation = Operation::new("verify-counter-delivery", false);
     let root = workspace_root()?;
+    operation.phase(
+        OperationPhase::Plan,
+        "check delivery artifacts, overlays, runbooks, deployables, and secrets",
+    );
     let mut failures = Vec::new();
     for relative_path in [
         "infra/security/sops/dev/counter-shared-db.enc.yaml",
@@ -533,6 +539,7 @@ pub(crate) fn verify_counter_delivery(mode: Mode) -> Result<()> {
             "counter shared DB secret verification failed: {error}"
         ));
     }
+    operation.phase(OperationPhase::Verify, "delivery evidence checks finished");
     if failures.is_empty() {
         println!("Counter delivery verification passed (promotion + drift + rollback)");
         return Ok(());
@@ -606,10 +613,16 @@ pub(crate) fn verify_generated_artifacts() -> Result<()> {
 }
 
 pub(crate) fn commit_golden_baseline() -> Result<()> {
+    let operation = Operation::new("commit-golden-baseline", true);
     let root = workspace_root()?;
     let golden_root = root.join("verification/golden");
+    operation.phase(
+        OperationPhase::Plan,
+        format!("update golden baselines under {}", golden_root.display()),
+    );
     println!("=== Committing golden baselines for all generated artifacts ===\n");
     println!("1. Generating platform catalog...");
+    operation.phase(OperationPhase::Execute, "generate platform catalog");
     if run_inherit(
         "cargo",
         &[
@@ -635,6 +648,7 @@ pub(crate) fn commit_golden_baseline() -> Result<()> {
     )?;
     println!();
     println!("3. Generating contract bindings...");
+    operation.phase(OperationPhase::Execute, "generate contract bindings");
     if run_inherit(
         "cargo",
         &["run", "-p", "repo-tools", "--", "typegen"],
@@ -682,6 +696,7 @@ pub(crate) fn commit_golden_baseline() -> Result<()> {
     }
     println!();
     println!("=============================================================");
+    operation.phase(OperationPhase::Verify, "golden baseline update completed");
     println!("  Golden baselines updated:");
     for dir in [
         "generated-platform",

--- a/tools/repo-tools/src/commands/secrets.rs
+++ b/tools/repo-tools/src/commands/secrets.rs
@@ -7,11 +7,12 @@ use std::process::{Command, Stdio};
 use anyhow::{Context, Result, bail};
 
 use crate::cli::{
-    SecretsArgs, SecretsCommand, SecretsDecryptEnvArgs, SecretsEnvArgs, SecretsReconcileArgs,
-    SecretsRunArgs,
+    SecretsArgs, SecretsCommand, SecretsDecryptEnvArgs, SecretsEditArgs, SecretsEncryptArgs,
+    SecretsEnvArgs, SecretsReconcileArgs, SecretsRunArgs,
 };
 use crate::support::{
-    collect_files_with_extension, normalize_slashes, read, require_tool, workspace_root,
+    collect_files_with_extension, normalize_slashes, read, require_tool, user_home_dir,
+    workspace_root,
 };
 
 const AGE_KEY_RELATIVE_PATH: &str = ".config/sops/age/key.txt";
@@ -23,6 +24,9 @@ pub(crate) fn run(args: SecretsArgs) -> Result<()> {
         SecretsCommand::VerifyCounterSharedDb(args) => verify_counter_shared_db_cli(args),
         SecretsCommand::Run(args) => run_with_secrets(args),
         SecretsCommand::Reconcile(args) => reconcile(args),
+        SecretsCommand::Encrypt(args) => encrypt(args),
+        SecretsCommand::Edit(args) => edit(args),
+        SecretsCommand::SetupFluxSecret => setup_flux_secret(),
         SecretsCommand::Validate => validate(),
     }
 }
@@ -256,6 +260,92 @@ fn validate() -> Result<()> {
     Ok(())
 }
 
+fn encrypt(args: SecretsEncryptArgs) -> Result<()> {
+    require_tool("sops", "mise install")?;
+    let root = workspace_root()?;
+    let source = root
+        .join("infra/security/sops/templates")
+        .join(&args.env)
+        .join(format!("{}.yaml", args.deployable));
+    if !source.is_file() {
+        bail!("template secret not found: {}", source.display());
+    }
+    let target = secret_path(&root, &args.env, &args.deployable);
+    println!(
+        "Encrypting secrets for deployable: {} ({})",
+        args.deployable, args.env
+    );
+    let output = Command::new("sops")
+        .args(["--encrypt", "--input-type", "yaml", "--output-type", "yaml"])
+        .arg(&source)
+        .output()
+        .with_context(|| format!("failed to encrypt {}", source.display()))?;
+    if !output.status.success() {
+        bail!("sops encrypt failed for {}", source.display());
+    }
+    std::fs::write(&target, output.stdout)
+        .with_context(|| format!("failed to write {}", target.display()))?;
+    println!("Encrypted: {}", target.display());
+    Ok(())
+}
+
+fn edit(args: SecretsEditArgs) -> Result<()> {
+    require_tool("sops", "mise install")?;
+    let root = workspace_root()?;
+    let target = secret_path(&root, &args.env, &args.deployable);
+    if !target.is_file() {
+        bail!("encrypted secret not found: {}", target.display());
+    }
+    println!("Editing: {} ({})", args.deployable, args.env);
+    let status = Command::new("sops")
+        .arg(&target)
+        .status()
+        .with_context(|| format!("failed to open sops for {}", target.display()))?;
+    if !status.success() {
+        bail!(
+            "sops edit failed with status {}",
+            status.code().unwrap_or(1)
+        );
+    }
+    println!("Saved (encrypted in place)");
+    Ok(())
+}
+
+fn setup_flux_secret() -> Result<()> {
+    require_tool("kubectl", "install kubectl and configure cluster access")?;
+    let age_key = age_key_path()?;
+    if !age_key.is_file() {
+        bail!(
+            "age key not found at {}. Generate one with `cargo run -p repo-tools -- dev age-key generate`",
+            age_key.display()
+        );
+    }
+
+    println!("Creating Flux SOPS secret in flux-system namespace");
+    let output = Command::new("kubectl")
+        .args([
+            "create",
+            "secret",
+            "generic",
+            "sops-age",
+            "--namespace",
+            "flux-system",
+            "--from-file",
+        ])
+        .arg(format!("age.agekey={}", age_key.display()))
+        .args(["--dry-run=client", "-o", "yaml"])
+        .output()
+        .context("failed to generate flux secret manifest")?;
+    if !output.status.success() {
+        bail!("kubectl create secret failed");
+    }
+
+    kubectl_apply(&String::from_utf8_lossy(&output.stdout))?;
+    println!("Flux SOPS secret created");
+    println!("Flux will now be able to decrypt SOPS-encrypted secrets");
+    Ok(())
+}
+
 fn decrypt_exports(path: &Path) -> Result<BTreeMap<String, String>> {
     let plain = decrypt_plain(path)?;
     parse_env_exports(&plain)
@@ -371,8 +461,7 @@ fn sops_age_key_file() -> Result<OsString> {
 }
 
 fn age_key_path() -> Result<PathBuf> {
-    let home = std::env::var_os("HOME").context("HOME is not set")?;
-    Ok(PathBuf::from(home).join(AGE_KEY_RELATIVE_PATH))
+    Ok(user_home_dir()?.join(AGE_KEY_RELATIVE_PATH))
 }
 
 fn read_age_public_key(path: &Path) -> Result<String> {

--- a/tools/repo-tools/src/commands/template.rs
+++ b/tools/repo-tools/src/commands/template.rs
@@ -343,20 +343,18 @@ struct Finding {
 
 fn backend_entry_files() -> &'static [&'static str] {
     &[
-        "package.json",
         ".moon/workspace.yml",
         "moon.yml",
         "justfile",
         "justfiles/setup.just",
         "justfiles/build.just",
         "justfiles/dev.just",
-        "justfiles/deploy.just",
-        "justfiles/processes.just",
-        "justfiles/test.just",
-        "justfiles/quality.just",
+        "justfiles/verify.just",
+        "justfiles/ops.just",
         "justfiles/platform.just",
         "justfiles/sops.just",
         "justfiles/template.just",
+        "justfiles/skills.just",
     ]
 }
 

--- a/tools/repo-tools/src/core/env.rs
+++ b/tools/repo-tools/src/core/env.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+
+pub(crate) fn user_home_dir() -> Result<PathBuf> {
+    if let Some(home) = std::env::var_os("HOME") {
+        return Ok(PathBuf::from(home));
+    }
+    if let Some(home) = std::env::var_os("USERPROFILE") {
+        return Ok(PathBuf::from(home));
+    }
+    let drive = std::env::var_os("HOMEDRIVE");
+    let path = std::env::var_os("HOMEPATH");
+    match (drive, path) {
+        (Some(drive), Some(path)) => {
+            let mut full = PathBuf::from(drive);
+            full.push(path);
+            Ok(full)
+        }
+        _ => bail!("HOME/USERPROFILE/HOMEDRIVE+HOMEPATH are not set"),
+    }
+}

--- a/tools/repo-tools/src/core/manifest.rs
+++ b/tools/repo-tools/src/core/manifest.rs
@@ -2,9 +2,61 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
+use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
 use crate::core::command::run_capture;
+use crate::core::fs::read;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RoutingRulesManifest {
+    #[serde(default)]
+    pub(crate) dispatch_order: Vec<String>,
+    #[serde(default)]
+    pub(crate) rules: Vec<RoutingRule>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RoutingRule {
+    pub(crate) r#match: String,
+    pub(crate) primary: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GateMatrixManifest {
+    #[serde(default)]
+    pub(crate) path_rules: Vec<GatePathRule>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct GatePathRule {
+    #[serde(default)]
+    pub(crate) r#match: Vec<String>,
+    #[serde(default)]
+    pub(crate) recommended: Vec<String>,
+    #[serde(default)]
+    pub(crate) required: Vec<String>,
+    #[serde(default)]
+    pub(crate) note: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct CodemapManifest {
+    #[serde(default)]
+    pub(crate) generated_readonly: Vec<String>,
+    #[serde(default)]
+    pub(crate) write_boundaries: BTreeMap<String, CodemapBoundary>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CodemapBoundary {
+    #[serde(default)]
+    pub(crate) may_modify: Vec<String>,
+    #[serde(default)]
+    pub(crate) must_not_modify: Vec<String>,
+}
 
 pub(crate) fn cargo_metadata(root: &Path) -> Result<JsonValue> {
     let outcome = run_capture(
@@ -23,6 +75,27 @@ pub(crate) fn cargo_metadata(root: &Path) -> Result<JsonValue> {
         );
     }
     serde_json::from_str(&outcome.output).context("failed to parse cargo metadata json")
+}
+
+pub(crate) fn load_routing_rules(root: &Path) -> Result<RoutingRulesManifest> {
+    load_yaml(root.join("agent/manifests/routing-rules.yml"))
+}
+
+pub(crate) fn load_gate_matrix(root: &Path) -> Result<GateMatrixManifest> {
+    load_yaml(root.join("agent/manifests/gate-matrix.yml"))
+}
+
+pub(crate) fn load_codemap(root: &Path) -> Result<CodemapManifest> {
+    load_yaml(root.join("agent/codemap.yml"))
+}
+
+fn load_yaml<T>(path: impl AsRef<Path>) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let path = path.as_ref();
+    serde_yaml::from_str(&read(path)?)
+        .with_context(|| format!("failed to parse {}", path.display()))
 }
 
 #[allow(dead_code)]

--- a/tools/repo-tools/src/core/mod.rs
+++ b/tools/repo-tools/src/core/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod command;
 pub(crate) mod context;
+pub(crate) mod env;
 pub(crate) mod external_tools;
 pub(crate) mod fs;
 pub(crate) mod git;
 pub(crate) mod manifest;
 pub(crate) mod mode;
+pub(crate) mod operation;
 pub(crate) mod pattern;
 pub(crate) mod report;

--- a/tools/repo-tools/src/core/operation.rs
+++ b/tools/repo-tools/src/core/operation.rs
@@ -1,0 +1,37 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OperationPhase {
+    Plan,
+    Preflight,
+    Execute,
+    Verify,
+}
+
+impl OperationPhase {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Plan => "plan",
+            Self::Preflight => "preflight",
+            Self::Execute => "execute",
+            Self::Verify => "verify",
+        }
+    }
+}
+
+pub(crate) struct Operation {
+    name: &'static str,
+    apply: bool,
+}
+
+impl Operation {
+    pub(crate) fn new(name: &'static str, apply: bool) -> Self {
+        Self { name, apply }
+    }
+
+    pub(crate) fn phase(&self, phase: OperationPhase, message: impl AsRef<str>) {
+        println!("[{}:{}] {}", self.name, phase.label(), message.as_ref());
+    }
+
+    pub(crate) fn is_apply(&self) -> bool {
+        self.apply
+    }
+}

--- a/tools/repo-tools/src/support.rs
+++ b/tools/repo-tools/src/support.rs
@@ -3,6 +3,8 @@ pub(crate) use crate::core::command::{CommandOutcome, run_capture, run_inherit};
 #[allow(unused_imports)]
 pub(crate) use crate::core::context::{WorkspaceContext, workspace_root};
 #[allow(unused_imports)]
+pub(crate) use crate::core::env::user_home_dir;
+#[allow(unused_imports)]
 pub(crate) use crate::core::external_tools::{Tool, command_exists_output, has_tool, require_tool};
 #[allow(unused_imports)]
 pub(crate) use crate::core::fs::{
@@ -19,6 +21,8 @@ pub(crate) use crate::core::manifest::{
 };
 #[allow(unused_imports)]
 pub(crate) use crate::core::mode::Mode;
+#[allow(unused_imports)]
+pub(crate) use crate::core::operation::{Operation, OperationPhase};
 #[allow(unused_imports)]
 pub(crate) use crate::core::pattern::{
     except_path, pattern_matches, same_module, strip_rust_comments,


### PR DESCRIPTION
## Summary
- Move more justfile process, worker, skills, secrets, ops, and observability flows behind `repo-tools` so `just` stays a thin command surface.
- Load routing, gate, and handoff metadata from manifests/codemap instead of duplicating rules in Rust.
- Add codemap module declarations required by strict existence checks and keep dev SOPS output aligned with the repo-tools encryption path.

## Verification
- `just verify`
- `just check-backend-primary`
- `just boundary-check`
- `just typecheck`
- `cargo run -p repo-tools -- route-task --paths agent/codemap.yml --paths agent/manifests/routing-rules.yml --paths tools/repo-tools/src/commands/harness.rs --paths justfiles/dev.just`
- `cargo run -p repo-tools -- validate-existence --mode strict`
- `cargo run -p repo-tools -- validate-state --mode strict`
- `cargo run -p repo-tools -- validate-workflows --mode strict`
- `cargo run -p repo-tools -- validate-resilience --mode warn`

## Notes
- `infra/security/sops/dev/web-bff.enc.yaml` was re-encrypted through the repo-tools path; decrypted contents match `origin/main`.
- This PR was created from a fresh follow-up branch based on `origin/main` after the previous `chore/rust-tooling-migration` PR was merged and its remote branch deleted.