### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,15 @@ A good change:
 5. adds or updates verification at the same semantic level as the risk
 6. avoids new hidden coupling, global state, and duplicated rules
 
+SOLID guidance for this repository:
+
+1. Treat SOLID as boundary discipline, not object-oriented ceremony.
+2. Keep each module focused on one reason to change: domain rules in `domain`/`application`, protocol adaptation in `servers`, async recovery in `workers`, and platform concerns in `platform`/`infra`/`ops`.
+3. Extend behavior through contracts, ports, traits, adapters, or composition roots; do not modify inner domain code to satisfy an outer transport, database, UI, or deployment concern.
+4. Keep trait contracts narrow enough that implementations can substitute safely. Split ports when callers do not need the same capabilities.
+5. Depend inward on stable abstractions. Production service code must not depend on concrete infrastructure adapters, app shells, workers, or other services directly.
+6. Allow test-only adapters and fixtures when they provide executable evidence, but do not use test exceptions to justify production dependency direction.
+
 Prefer boring, explicit, well-named code. Introduce abstractions only when they remove real duplication or clarify a stable boundary.
 
 Avoid these anti-patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,28 @@ Preferred release views:
 - Releases: <https://github.com/openclosed-org/axum-harness/releases>
 - Tags: <https://github.com/openclosed-org/axum-harness/tags>
 
-## Unreleased
+## v0.3.1 - 2026-04-29
 
 ### Changed
 
+- Replaced the legacy TypeScript and shell script control plane with the Rust `repo-tools` CLI so reusable validation, generation, drift, routing, secret, infra, ops, worker, and app helper logic lives behind structured commands.
+- Tightened the `repo-tools` control plane with explicit environment handling, operation phases, manifest helpers, and expanded repo command coverage.
+- Consolidated root `just` and `moon` task wiring around the Rust repo-control surface while keeping human-facing recipes thin.
 - Consolidated release-plz changelog output into the root `CHANGELOG.md` so the template has one public change history.
 - Clarified that the root `axum-harness` package is an upstream maintainer release anchor, not a required derived-project runtime contract.
+- Clarified contribution governance, pull request expectations, issue templates, maintainer decision guidance, and SOPS-backed local development workflows.
+- Simplified the root README entrypoint so adopters start from the current template posture instead of stale broad guidance.
+- Added explicit SOLID guidance to the agent protocol, framed as boundary discipline for services, servers, workers, platform, ports, traits, adapters, and composition roots.
 
 ### Fixed
 
 - Extended `template-init backend-core apply` so derived projects can remove the upstream release-plz workflow, runtime config, repo-release helper, and root release anchor together.
+- Aligned the platform state ownership map with service-local semantics so platform metadata points at the right domain owners without claiming runtime proof.
+
+### Migration Notes
+
+- Use the Rust `repo-tools` entrypoints behind `just` recipes instead of removed legacy scripts under `scripts/**`, `infra/**/scripts/**`, and `ops/**/migrations/**`.
+- Treat the new SOLID guidance as an extension of the existing boundary rules: production service code depends inward on contracts, ports, traits, and shared abstractions; test-only adapters remain allowed when they provide executable evidence.
 
 ## v0.3.0 - 2026-04-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "axum-harness"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "backtrace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-harness"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false


### PR DESCRIPTION
## Summary
- Add explicit SOLID-as-boundary-discipline guidance to `AGENTS.md`.
- Promote the repository release anchor to `0.3.1` and organize all commits after `v0.3.0` into the `v0.3.1` changelog entry.
- Keep the changelog focused on repo-tools control plane migration, platform ownership alignment, governance/docs updates, and migration notes.

## Verification
- `just boundary-check`
- `just check-backend-primary`

## Release Notes
- `v0.3.1` covers commits from `v0.3.0..HEAD` before this PR plus the SOLID guidance/release preparation change.