### PR TITLE
chore(release): prepare v0.4.0 contract reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ Preferred release views:
 - Releases: <https://github.com/openclosed-org/axum-harness/releases>
 - Tags: <https://github.com/openclosed-org/axum-harness/tags>
 
+## v0.4.0 - 2026-05-04
+
+### Changed
+
+- Switched the HTTP contract generation path to the web-bff `utoipa-axum` route collection so generated OpenAPI is produced from Axum handlers plus the live Rust DTO schemas.
+- Reset the contract artifact layout around `packages/contracts/generated/openapi/web-bff.openapi.yaml` and removed the legacy `ts-rs` TypeScript binding output from the backend-core contract surface.
+- Tightened release and template gates so repository release automation checks the selected SemVer compatibility line before preparing release state.
+- Streamlined agent, architecture, command, and gate guidance around executable evidence, backend-core boundaries, replay/resilience semantics, and generated-artifact ownership.
+
+### Fixed
+
+- Hardened counter outbox delivery and worker replay/resilience verification so idempotency, recovery, and projection semantics have stronger executable coverage.
+- Aligned generated artifact baselines after the OpenAPI contract source reset.
+
+### Breaking Changes
+
+- `packages/contracts/api` no longer exposes legacy DTOs that only existed for the removed `ts-rs` TypeScript binding pipeline, including agent/admin/conversation DTOs and the old local `ErrorResponse`; HTTP error responses now use `contracts_errors::ErrorResponse` and HTTP API consumers should treat the generated OpenAPI artifact as the external contract reference.
+- TypeScript consumers should stop importing generated files from `packages/contracts/generated/api/**` and consume the generated OpenAPI contract or SDK output produced from it instead.
+
+### Migration Notes
+
+- Regenerate HTTP contract artifacts with `just typegen` after route or DTO changes, then verify drift with `just drift-check` and contract checks with `just verify-contracts strict`.
+- For release checks that intentionally cross this contract boundary, run the repository SemVer gate with the `major` compatibility expectation instead of weakening the contract API surface for a minor check.
+
 ## v0.3.1 - 2026-04-29
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "axum-harness"
-version = "0.3.1"
+version = "0.4.0"
 
 [[package]]
 name = "backtrace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-harness"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/packages/contracts/api/src/lib.rs
+++ b/packages/contracts/api/src/lib.rs
@@ -3,8 +3,7 @@
 
 #![deny(unused_imports, unused_variables)]
 
-use serde::{Deserialize, Serialize, ser::SerializeStruct};
-use std::fmt;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
@@ -55,118 +54,11 @@ impl InitTenantResponse {
     }
 }
 
-/// Chat message (user or assistant).
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ChatMessage {
-    pub id: String,
-    pub conversation_id: String,
-    /// "user" | "assistant" | "system" | "tool"
-    pub role: String,
-    pub content: String,
-    pub tool_calls: Option<Vec<ToolCall>>,
-    pub created_at: String,
-}
-
-/// Tool call in a chat message.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ToolCall {
-    pub id: String,
-    pub name: String,
-    pub arguments: serde_json::Value,
-    pub result: Option<String>,
-}
-
-/// Agent configuration (user-provided API key + endpoint).
-#[derive(Clone, Deserialize, ToSchema)]
-pub struct AgentConfig {
-    /// API key — omitted from serialized payloads to prevent accidental exposure.
-    pub api_key: String,
-    pub base_url: String,
-    pub model: String,
-}
-
-impl Serialize for AgentConfig {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("AgentConfig", 2)?;
-        state.serialize_field("base_url", &self.base_url)?;
-        state.serialize_field("model", &self.model)?;
-        state.end()
-    }
-}
-
-impl fmt::Debug for AgentConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AgentConfig")
-            .field("api_key", &"[REDACTED]")
-            .field("base_url", &self.base_url)
-            .field("model", &self.model)
-            .finish()
-    }
-}
-
-/// Admin dashboard statistics.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct AdminDashboardStats {
-    pub tenant_count: u64,
-    pub counter_value: i64,
-    pub last_login: Option<String>,
-    pub app_version: String,
-}
-
 /// Generic counter operation response.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CounterResponse {
     /// The current counter value after the operation.
     pub value: i64,
-}
-
-/// Legacy generic error response kept for public Rust API compatibility.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ErrorResponse {
-    /// Error message describing what went wrong.
-    pub error: String,
-}
-
-/// Agent conversation summary.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ConversationSummary {
-    pub id: String,
-    pub title: String,
-    pub created_at: String,
-    pub updated_at: String,
-}
-
-/// Agent conversation with messages.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ConversationDetail {
-    pub id: String,
-    pub title: String,
-    pub messages: Vec<ChatMessage>,
-}
-
-/// Request body for creating an agent conversation.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct CreateConversationRequest {
-    /// Conversation title.
-    pub title: String,
-}
-
-/// Request body for agent chat.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ChatRequest {
-    /// The conversation ID to continue or create.
-    pub conversation_id: String,
-    /// User message content.
-    pub content: String,
-    /// LLM API key (provided by client, not stored).
-    pub api_key: String,
-    /// LLM API base URL.
-    pub base_url: String,
-    /// Model name to use.
-    pub model: String,
 }
 
 /// Current authenticated user profile.
@@ -205,60 +97,5 @@ mod tests {
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("tenant_name"));
         assert!(json.contains("null"));
-    }
-
-    #[test]
-    fn agent_config_serialize_redacts_api_key() {
-        let config = AgentConfig {
-            api_key: "sk-secret-key-12345".to_string(),
-            base_url: "https://api.example.com".to_string(),
-            model: "gpt-4".to_string(),
-        };
-
-        let json = serde_json::to_string(&config).unwrap();
-
-        assert!(
-            !json.contains("sk-secret-key-12345"),
-            "api_key must not appear in serialized JSON"
-        );
-        assert!(
-            !json.contains("api_key"),
-            "api_key field must be omitted from serialized JSON"
-        );
-        assert!(json.contains("base_url"));
-        assert!(json.contains("model"));
-    }
-
-    #[test]
-    fn agent_config_deserialize_populates_api_key() {
-        let json =
-            r#"{"api_key":"sk-from-json","base_url":"https://api.example.com","model":"gpt-4"}"#;
-        let config: AgentConfig = serde_json::from_str(json).unwrap();
-
-        assert_eq!(config.api_key, "sk-from-json");
-        assert_eq!(config.base_url, "https://api.example.com");
-        assert_eq!(config.model, "gpt-4");
-    }
-
-    #[test]
-    fn agent_config_debug_redacts_api_key() {
-        let config = AgentConfig {
-            api_key: "sk-secret-key-12345".to_string(),
-            base_url: "https://api.example.com".to_string(),
-            model: "gpt-4".to_string(),
-        };
-
-        let debug_str = format!("{:?}", config);
-
-        assert!(
-            !debug_str.contains("sk-secret-key-12345"),
-            "api_key must not appear in Debug output"
-        );
-        assert!(
-            debug_str.contains("[REDACTED]"),
-            "Debug output must contain [REDACTED]"
-        );
-        assert!(debug_str.contains("base_url"));
-        assert!(debug_str.contains("model"));
     }
 }


### PR DESCRIPTION
## Summary
- Prepare the repository release anchor for v0.4.0 after the HTTP contract source reset.
- Keep contracts_api aligned with the utoipa-axum/OpenAPI source of truth instead of restoring removed ts-rs DTOs.
- Document the breaking contract migration in CHANGELOG.md.

## Verification
- rtk cargo test -p contracts_api
- just semver-check 'v0.3.1' 'major' 'v[0-9]*.[0-9]*.[0-9]*'
- just drift-check
- just verify-contracts strict
- rtk cargo test -p web-bff
- rtk cargo test -p repo-tools
- rtk cargo check --workspace --exclude axum-harness
- RELEASE_TYPE=major just gate-release (passed semver/drift/backend-core audit; timed out during nested ci gate)