### PR TITLE
ci(release): make release cuts manual

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -213,6 +213,7 @@ jobs:
 
   semver:
     name: Repository SemVer Check
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -334,12 +335,14 @@ jobs:
           echo "| Supply Chain Scan | ${{ needs.supply-chain.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
+          semver_result="${{ needs.semver.result }}"
+
           if [ "${{ needs.security.result }}" = "success" ] && \
              [ "${{ needs.governance-static.result }}" = "success" ] && \
              [ "${{ needs.secondary-runtime.result }}" = "success" ] && \
              [ "${{ needs.platform-drift.result }}" = "success" ] && \
              [ "${{ needs.contract-drift.result }}" = "success" ] && \
-             [ "${{ needs.semver.result }}" = "success" ] && \
+             { [ "$semver_result" = "success" ] || [ "$semver_result" = "skipped" ]; } && \
              [ "${{ needs.validation-scripts.result }}" = "success" ] && \
              [ "${{ needs.supply-chain.result }}" = "success" ]; then
             echo "All governance checks passed." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,36 +1,6 @@
 name: Release Automation
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/release-plz.yml'
-      - 'release-plz.toml'
-      - 'release-plz.template.toml'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'Justfile'
-      - 'justfiles/template.just'
-      - 'tools/repo-release/**'
-      - 'servers/**'
-      - 'services/**'
-      - 'workers/**'
-      - 'platform/**'
-      - 'packages/contracts/**'
-      - 'packages/kernel/**'
-      - 'packages/platform/**'
-      - 'packages/runtime/**'
-      - 'packages/messaging/**'
-      - 'packages/data/**'
-      - 'packages/data-traits/**'
-      - 'packages/data-adapters/**'
-      - 'packages/authn/**'
-      - 'packages/authz/**'
-      - 'packages/observability/**'
-      - 'docs/**'
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'CHANGELOG.md'
   workflow_dispatch:
     inputs:
       release_tag_template:
@@ -47,7 +17,7 @@ on:
         type: string
       release_type:
         description: SemVer compatibility expectation for the repository release line
-        required: false
+        required: true
         type: choice
         default: minor
         options:
@@ -57,7 +27,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -88,7 +57,6 @@ jobs:
           INPUT_RELEASE_TAG_GLOB: ${{ inputs.release_tag_glob }}
           INPUT_BASELINE_TAG: ${{ inputs.baseline_tag }}
           INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
-          VAR_RELEASE_TYPE: ${{ vars.RELEASE_TYPE }}
           VAR_RELEASE_TAG_TEMPLATE: ${{ vars.RELEASE_TAG_TEMPLATE }}
           VAR_RELEASE_TAG_GLOB: ${{ vars.RELEASE_TAG_GLOB }}
           VAR_RELEASE_BOOTSTRAP_TAG: ${{ vars.RELEASE_BOOTSTRAP_TAG }}
@@ -96,7 +64,7 @@ jobs:
           release_tag_template="${INPUT_RELEASE_TAG_TEMPLATE:-${VAR_RELEASE_TAG_TEMPLATE:-v{{ version }}}}"
           release_tag_glob="${INPUT_RELEASE_TAG_GLOB:-${VAR_RELEASE_TAG_GLOB:-v[0-9]*.[0-9]*.[0-9]*}}"
           baseline_tag="${INPUT_BASELINE_TAG:-${VAR_RELEASE_BOOTSTRAP_TAG:-}}"
-          release_type="${INPUT_RELEASE_TYPE:-${VAR_RELEASE_TYPE:-minor}}"
+          release_type="$INPUT_RELEASE_TYPE"
 
           case "$release_type" in
             patch|minor|major) ;;
@@ -155,73 +123,9 @@ jobs:
       - name: Run repository semver check
         run: just semver-check '${{ needs.release-line.outputs.baseline_tag }}' '${{ needs.release-line.outputs.release_type }}' '${{ needs.release-line.outputs.release_tag_glob }}'
 
-  release-pr:
-    name: Release PR
-    runs-on: ubuntu-latest
-    needs: [release-line, semver]
-    if: needs.release-line.outputs.has_repo_tag == 'true'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@1800853f2578f8c34492ec76154caef8e163fbca
-
-      - name: Install release-plz
-        run: |
-          cargo binstall \
-            release-plz@0.3.157 \
-            --force \
-            --strategies=crate-meta-data,compile \
-            --no-confirm
-
-      - name: Configure git user
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Render release-plz config
-        env:
-          RELEASE_TAG_TEMPLATE: ${{ needs.release-line.outputs.release_tag_template }}
-        run: |
-          mkdir -p "$RUNNER_TEMP/release-plz"
-          RELEASE_TAG_TEMPLATE="$RELEASE_TAG_TEMPLATE" perl -0pe 's/__REPOSITORY_TAG_TEMPLATE__/$ENV{RELEASE_TAG_TEMPLATE}/g' release-plz.template.toml > "$RUNNER_TEMP/release-plz/release-plz.runtime.toml"
-
-      - name: Extract baseline release manifest
-        env:
-          BASELINE_TAG: ${{ needs.release-line.outputs.baseline_tag }}
-        run: |
-          mkdir -p "$RUNNER_TEMP/release-plz/baseline"
-          if git show "${BASELINE_TAG}:Cargo.toml" | grep -q 'name = "axum-harness"'; then
-            git show "${BASELINE_TAG}:Cargo.toml" > "$RUNNER_TEMP/release-plz/baseline/Cargo.toml"
-          else
-            git show "${BASELINE_TAG}:tools/repo-release/Cargo.toml" > "$RUNNER_TEMP/release-plz/baseline/Cargo.toml"
-          fi
-
-      - name: Run release-plz release-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          release-plz release-pr \
-            --git-token "${GITHUB_TOKEN}" \
-            --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
-            --manifest-path Cargo.toml \
-            --registry-manifest-path "$RUNNER_TEMP/release-plz/baseline/Cargo.toml" \
-            --package axum-harness \
-            --forge github \
-            --config "$RUNNER_TEMP/release-plz/release-plz.runtime.toml" \
-            -o json
-
   release:
     name: GitHub Release
-    if: github.event_name == 'workflow_dispatch' && needs.release-line.outputs.has_repo_tag == 'true'
+    if: needs.release-line.outputs.has_repo_tag == 'true'
     runs-on: ubuntu-latest
     needs: [release-line, semver]
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,9 @@ For general readers and template adopters:
 2. `docs/architecture/north-star.md`
 3. `docs/operations/local-dev.md`
 4. `docs/operations/counter-service-reference-chain.md`
-5. `docs/operations/secret-management.md`
-6. `docs/template-users/template-init.md`
+5. `docs/operations/release-process.md`
+6. `docs/operations/secret-management.md`
+7. `docs/template-users/template-init.md`
 
 For maintainers and agent-assisted development:
 
@@ -71,8 +72,11 @@ This upstream repository is versioned as a single template product. The release 
 
 1. the repository tag/release is the version contract template users should follow
 2. pre-`1.0.0` releases cover iterative template improvements, docs fixes, tooling updates, and internal refactors within the active pre-1.0 line
-3. bump the minor version when template structure, migration expectations, or public usage patterns change materially
-4. start `1.0.0` only when the template is ready to make a stronger stability promise to adopters
+3. ordinary PRs and `main` pushes accumulate unreleased changes; they do not automatically publish tags
+4. prepare version and changelog updates in an intentional release-prep PR when maintainers decide to cut a release
+5. run `Release Automation` manually with the selected `release_type` to publish the prepared release
+6. bump the minor version when template structure, migration expectations, or public usage patterns change materially
+7. start `1.0.0` only when the template is ready to make a stronger stability promise to adopters
 
 Cargo crate versions still exist as workspace metadata, but they do not represent independent product release channels. The root `axum-harness` package is a maintainer-only release anchor with `publish = false`; it is not required for projects derived from the template.
 
@@ -84,7 +88,7 @@ Maintainers can override the default release tag strategy without changing track
 2. `RELEASE_TAG_GLOB` controls which tags CI treats as the current release line, defaulting to `v[0-9]*.[0-9]*.[0-9]*`
 3. `RELEASE_BOOTSTRAP_TAG` can pin an explicit existing tag as the release baseline until the next official tag is created
 
-`release-plz` prepares repository releases and updates the root `CHANGELOG.md`. `just semver-check` is the local visibility check for repository-level compatibility assumptions within the active pre-1.0 line.
+`release-plz` publishes prepared repository releases only when maintainers trigger it manually. `just semver-check` is the local visibility check for repository-level compatibility assumptions within the active pre-1.0 line. See `docs/operations/release-process.md` before changing release automation, version anchors, or changelog policy.
 
 ### Configuration
 

--- a/docs/operations/release-process.md
+++ b/docs/operations/release-process.md
@@ -1,0 +1,84 @@
+# Release Process
+
+This repository releases as one upstream template product. Tags and GitHub Releases are the public version contract; ordinary PRs and `main` pushes do not automatically update versions or publish tags.
+
+## Consensus
+
+1. Regular PRs accumulate unreleased changes on `main`.
+2. A release is a maintainer decision, not a side effect of every merge.
+3. `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` are updated in an intentional release-prep change.
+4. `release-plz` runs only when a maintainer manually triggers the release workflow.
+5. SemVer checks must express the selected release line. Do not restore obsolete APIs only to satisfy a `minor` gate when the intended release is breaking.
+6. For the pre-`1.0.0` template line, a material public contract reset such as `0.3.x -> 0.4.0` is checked with the `major` compatibility expectation because Rust public API removals are allowed only in that mode.
+
+## Normal PR Flow
+
+Ordinary PRs should keep the codebase healthy without forcing a version bump.
+
+Expected evidence depends on changed paths, but common checks are:
+
+```bash
+just drift-check
+just verify-contracts strict
+just check-backend-primary
+```
+
+The governance SemVer job runs on pull requests as a breaking-change detector. If a PR intentionally removes or renames public Rust API, mark the PR explicitly with a breaking signal such as a conventional commit `!` marker or a `BREAKING CHANGE:` footer. That signal documents release impact; it does not publish a version.
+
+`main` push workflows should not fail merely because accumulated unreleased changes will require a future breaking release. The blocking release SemVer gate belongs to the release cut.
+
+## Preparing A Release
+
+When maintainers decide to publish accumulated changes, create a release-prep PR.
+
+1. Choose the next repository version, for example `0.4.0`.
+2. Choose the release compatibility expectation: `patch`, `minor`, or `major`.
+3. Update the root release anchor in `Cargo.toml`.
+4. Update the matching `axum-harness` entry in `Cargo.lock`.
+5. Add a new `CHANGELOG.md` section with changed behavior, fixes, breaking changes, and migration notes.
+6. Run the release SemVer check against the previous tag.
+
+Example for the current `v0.4.0` contract reset:
+
+```bash
+just semver-check 'v0.3.1' 'major' 'v[0-9]*.[0-9]*.[0-9]*'
+just drift-check
+just verify-contracts strict
+```
+
+If the release is not breaking, use `patch` or `minor` instead of `major`. Do not use `major` as a way to hide accidental API deletion; use it only when the release notes and migration guidance intentionally describe a breaking release.
+
+## Publishing A Release
+
+After the release-prep PR is merged to `main`, a maintainer publishes by manually running the `Release Automation` workflow from GitHub Actions.
+
+Required input:
+
+1. `release_type`: choose `patch`, `minor`, or `major` to match the prepared release.
+
+Optional inputs:
+
+1. `baseline_tag`: explicit existing tag to compare against, for example `v0.3.1`.
+2. `release_tag_template`: defaults to `v{{ version }}`.
+3. `release_tag_glob`: defaults to `v[0-9]*.[0-9]*.[0-9]*`.
+
+For the current `v0.4.0` release, run:
+
+```bash
+gh workflow run release-plz.yml \
+  --ref main \
+  -f release_type=major \
+  -f baseline_tag=v0.3.1
+```
+
+The workflow runs the repository SemVer check with the selected expectation and then invokes `release-plz` to create the GitHub Release/tag from the prepared root release anchor.
+
+## Agent Guidance
+
+When an agent sees release or SemVer failures:
+
+1. First identify whether the workflow is a normal PR/main validation or a maintainer-triggered release cut.
+2. Do not restore deleted DTOs, generated bindings, or obsolete compatibility layers just to satisfy a mismatched `minor` check.
+3. If the change is intentionally breaking, ensure the release-prep PR and `CHANGELOG.md` say so and run `just semver-check <baseline> major <tag_glob>`.
+4. If the change is not intended to be breaking, repair the causal API deletion at the owning boundary.
+5. If the user asks how to update the version/tag, tell them to prepare a release PR first, then manually trigger `Release Automation` with the appropriate `release_type`.


### PR DESCRIPTION
## Summary
- Stop running Release Automation on every main push; releases now require an explicit workflow_dispatch.
- Keep repository SemVer as a PR breaking-change detector while allowing main to accumulate unreleased changes.
- Document the release-prep and publish workflow so agents and maintainers know how to update versions/tags intentionally.

## Verification
- just validate-state strict
- just verify-contracts strict
- just semver-check 'v0.3.1' 'major' 'v[0-9]*.[0-9]*.[0-9]*'
- just drift-check
- rtk cargo check --workspace --exclude axum-harness
- rtk cargo test -p repo-tools
- rtk git diff --check