### PR TITLE
chore(release): align v0.4.1 release anchor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "axum-harness"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "backtrace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-harness"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false


### PR DESCRIPTION
## Summary
- Align the root `axum-harness` release anchor with the prepared `CHANGELOG.md` `v0.4.1` section.
- Update the matching `Cargo.lock` package entry so the maintainer-triggered release workflow can publish `v0.4.1` from `main`.

## Verification
- `rtk cargo check -p axum-harness`

## Release Context
The `v0.4.1` changelog section is already present on `main`, but the root release anchor still reported `0.4.0`. This PR completes the release-prep state required by `docs/operations/release-process.md` before running `Release Automation`.