### PR TITLE
fix(security): update vulnerable openssl lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5449,15 +5449,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5487,9 +5486,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -6247,7 +6246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.16.1",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.6",
 ]

--- a/workers/outbox-relay/src/polling/mod.rs
+++ b/workers/outbox-relay/src/polling/mod.rs
@@ -321,14 +321,23 @@ impl<R: OutboxReader> OutboxPoller<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    fn test_checkpoint_path() -> &'static str {
-        "/tmp/outbox-poller-test-checkpoint.json"
+    fn test_checkpoint_path(test_name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "outbox-poller-{test_name}-{}-{nanos}.json",
+            std::process::id()
+        ))
     }
 
     #[tokio::test]
     async fn poll_cycle_returns_pending_entries() {
-        let _ = std::fs::remove_file(test_checkpoint_path());
+        let checkpoint_path = test_checkpoint_path("returns-pending");
         let entries = vec![PendingOutboxEntry {
             id: "entry-1".to_string(),
             sequence: 1,
@@ -343,7 +352,7 @@ mod tests {
             reader,
             PollerConfig::default(),
             Box::new(worker_runtime::FileCheckpointStore::new(
-                test_checkpoint_path(),
+                checkpoint_path.to_str().unwrap(),
                 0,
             )),
             Box::<worker_runtime::FileDedupeStore>::default(),
@@ -352,12 +361,12 @@ mod tests {
         let result = poller.poll_cycle().await;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, "entry-1");
-        let _ = std::fs::remove_file(test_checkpoint_path());
+        let _ = std::fs::remove_file(checkpoint_path);
     }
 
     #[tokio::test]
     async fn poll_cycle_skips_duplicates() {
-        let _ = std::fs::remove_file(test_checkpoint_path());
+        let checkpoint_path = test_checkpoint_path("skips-duplicates");
         let entries = vec![PendingOutboxEntry {
             id: "entry-1".to_string(),
             sequence: 1,
@@ -372,7 +381,7 @@ mod tests {
             reader,
             PollerConfig::default(),
             Box::new(worker_runtime::FileCheckpointStore::new(
-                test_checkpoint_path(),
+                checkpoint_path.to_str().unwrap(),
                 0,
             )),
             Box::<worker_runtime::FileDedupeStore>::default(),
@@ -388,12 +397,12 @@ mod tests {
         poller.reader = reader2;
         let result2 = poller.poll_cycle().await;
         assert_eq!(result2.len(), 0);
-        let _ = std::fs::remove_file(test_checkpoint_path());
+        let _ = std::fs::remove_file(checkpoint_path);
     }
 
     #[tokio::test]
     async fn mark_processed_by_id_does_not_checkpoint_failed_entries() {
-        let _ = std::fs::remove_file(test_checkpoint_path());
+        let checkpoint_path = test_checkpoint_path("partial-checkpoint");
         let entries = vec![
             PendingOutboxEntry {
                 id: "entry-1".to_string(),
@@ -419,7 +428,7 @@ mod tests {
             reader,
             PollerConfig::default(),
             Box::new(worker_runtime::FileCheckpointStore::new(
-                test_checkpoint_path(),
+                checkpoint_path.to_str().unwrap(),
                 0,
             )),
             Box::<worker_runtime::FileDedupeStore>::default(),
@@ -432,6 +441,6 @@ mod tests {
         let result = poller.poll_cycle().await;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, "entry-2");
-        let _ = std::fs::remove_file(test_checkpoint_path());
+        let _ = std::fs::remove_file(checkpoint_path);
     }
 }


### PR DESCRIPTION
## Summary
- Updates Cargo.lock from openssl 0.10.78 to 0.10.79 to clear CVE-2026-42327 in the Quality Gate supply-chain scan.
- Isolates outbox poller tests so concurrent test execution does not share a fixed /tmp checkpoint file.

## Verification
- cargo check --locked --workspace
- cargo test -p outbox-relay-worker
- trivy fs --severity HIGH,CRITICAL --exit-code 1 --skip-dirs target .
- pre-push hook: cargo run -p repo-tools -- gate prepush --mode strict